### PR TITLE
Fix floating-point number issue

### DIFF
--- a/src/JSqueak/SqueakObject.java
+++ b/src/JSqueak/SqueakObject.java
@@ -301,10 +301,12 @@ public class SqueakObject //Later make variants for common formats
             else if (sqClass==floatClass) 
             {
                 //Floats need two ints to be converted to double
-                long longBits= (((long)((int[])bits)[0])<<32) | (((long)((int[])bits)[0])&0xFFFFFFFF);
-                //System.err.println();
-                //System.err.println(((int[])bits)[0] + " " + ((int[])bits)[1] + " -> " + longBits);
-                bits= new Double(Double.longBitsToDouble(longBits)); 
+                long higherBits = ((long) ((int[]) bits)[0]) << 32;
+                //Use unsigned right shift operator to ignore negative sign
+                long lowerBits = ((long) ((int[]) bits)[1] << 32) >>> 32;
+                long longBits = higherBits | lowerBits;
+
+                bits = Double.longBitsToDouble(longBits);
             }
             //System.err.println((Double)bits + " " + Double.doubleToRawLongBits(((Double)bits).doubleValue()));
         }


### PR DESCRIPTION
Fix a bug when reading floating-point numbers from image file:

Original code:
`long longBits= (((long)((int[])bits)[0])<<32) | (((long)((int[])bits)[0])&0xFFFFFFFF);`
 (wrong index number & overflow)

Since squeak's floats need two ints to be converted to double, it is necessary to ignore negative sign while converting, otherwise Double.longBitsToDouble may fail due to overflow.

To fix this, simply use the >>> operator when dealing with lower bits.

As an immediate result, the "Welcome to Mini Squeak 2.2" window can be resized or moved correctly.
This should also fix other incorrect behaviors caused by those floating-point numbers.