### PR TITLE
Add support for window resizing, reformat code with IntelliJ IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,25 @@
-/build/
+build
+
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+JSqueak

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="11" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/classes" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/JSqueak.iml" filepath="$PROJECT_DIR$/JSqueak.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/JSqueak.iml
+++ b/JSqueak.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <output url="file://$MODULE_DIR$/build" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="inheritedJdk" />
+  </component>
+</module>

--- a/src/JSqueak/BitBlt.java
+++ b/src/JSqueak/BitBlt.java
@@ -751,13 +751,13 @@ public class BitBlt {
                 destWord = destWord | ((destPix & dstMask) << dstShift);
                 /* adjust source pix index */
                 dstShift += dstShiftInc;
-                if (!(((srcShift += srcShiftInc) & AllOnes) == 0)) {
+                if (!(((srcShift += srcShiftInc) & 0xFFFFFFE0) == 0)) {
                     if (source.msb) {
                         srcShift += 32;
                     } else {
                         srcShift -= 32;
                     }
-                    sourceWord = srcLongAt(sourceIndex += 4);
+                    sourceWord = srcLongAt(sourceIndex += 1);
                 }
             } while (!((nPix -= 1) == 0));
         } /*clean double-neg here*/ else {
@@ -768,7 +768,7 @@ public class BitBlt {
                 destWord = destWord | ((destPix & dstMask) << dstShift);
                 /* adjust source pix index */
                 dstShift += dstShiftInc;
-                if (!(((srcShift += srcShiftInc) & AllOnes) == 0)) {
+                if (!(((srcShift += srcShiftInc) & 0xFFFFFFE0) == 0)) {
                     if (source.msb) {
                         srcShift += 32;
                     } else {

--- a/src/JSqueak/BitBlt.java
+++ b/src/JSqueak/BitBlt.java
@@ -27,13 +27,12 @@ import java.awt.Rectangle;
 
 /**
  * @author Dan Ingalls
- *
+ * <p>
  * Will eventually implement the full BitBlt plus Warp Drive(tm)
  */
-public class BitBlt 
-{
+public class BitBlt {
     private SqueakVM vm;
-        
+
     private Object destForm;
     SqueakVM.FormCache dest;
     private int destX, destY, width, height;
@@ -59,14 +58,14 @@ public class BitBlt
     private boolean destIsDisplay;
     private int clipX, clipY, clipWidth, clipHeight;
     private boolean isWarping;
-            int combinationRule;
-            int bitCount;
+    int combinationRule;
+    int bitCount;
     private int skew;
-    private int mask1,mask2;
+    private int mask1, mask2;
     private boolean preload;
     private int nWords;
     private int destMask;
-    private int hDir,vDir;
+    private int hDir, vDir;
     private int sx, sy;
     private int dx, dy;
     private int bbW, bbH;
@@ -91,168 +90,153 @@ public class BitBlt
     private int[] cmMaskTable;
     private int[] cmLookupTable;
     private int cmBitsPerColor;
-            
-    final static int FN_XOR= 2;
-    final static int FN_STORE_CONST= 12;
-    final static int AllOnes= 0xFFFFFFFF;
-    
-    private final static int maskTable[]= {
-        // Squeak's table for masking pixels within a word, based on depth'
-        //  #(1 2 4 5 8 16 32) do:[:i| maskTable at: i put: (1 << i)-1].
-        0x1, 0x3, 0, 0xF, 0x1F, 0, 0, 0xFF,
-        0, 0, 0, 0, 0, 0, 0, 0xFFFF,
-        0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0xFFFFFFFF };
-    
-    BitBlt(SqueakVM theVM) 
-    {
-        vm= theVM;
-        dest= vm.newFormCache();
-        source= vm.newFormCache();
+
+    final static int FN_XOR = 2;
+    final static int FN_STORE_CONST = 12;
+    final static int AllOnes = 0xFFFFFFFF;
+
+    private final static int maskTable[] = {
+            // Squeak's table for masking pixels within a word, based on depth'
+            //  #(1 2 4 5 8 16 32) do:[:i| maskTable at: i put: (1 << i)-1].
+            0x1, 0x3, 0, 0xF, 0x1F, 0, 0, 0xFF,
+            0, 0, 0, 0, 0, 0, 0, 0xFFFF,
+            0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0xFFFFFFFF};
+
+    BitBlt(SqueakVM theVM) {
+        vm = theVM;
+        dest = vm.newFormCache();
+        source = vm.newFormCache();
     }
-    
-    boolean loadBitBlt(SqueakObject bbObject, 
-                       int argCount,  
+
+    boolean loadBitBlt(SqueakObject bbObject,
+                       int argCount,
                        boolean doWarp,
-                       SqueakObject displayForm) 
-    {
-        success= true;
+                       SqueakObject displayForm) {
+        success = true;
         isWarping = doWarp;
-        Object[] bbPointers= bbObject.pointers;
+        Object[] bbPointers = bbObject.pointers;
         combinationRule = checkIntValue(bbPointers[3]);
-        if (!success || (combinationRule < 0) || (combinationRule > (41 - 2))) 
+        if (!success || (combinationRule < 0) || (combinationRule > (41 - 2)))
             return false;
-        if (combinationRule >= 16 && combinationRule <= 17) 
+        if (combinationRule >= 16 && combinationRule <= 17)
             return false;
         destForm = bbPointers[0];
         sourceForm = bbPointers[1];
         noSource = ignoreSourceOrHalftone(sourceForm);
         halftoneForm = bbPointers[2];
         noHalftone = ignoreSourceOrHalftone(halftoneForm);
-        if (!dest.loadFrom(destForm)) 
+        if (!dest.loadFrom(destForm))
             return false;
-        if (!loadBBDestRect(bbPointers)) 
+        if (!loadBBDestRect(bbPointers))
             return false;
-        if (!success) 
+        if (!success)
             return false;
-        if (noSource) 
-        {
+        if (noSource) {
             sourceX = sourceY = 0;
-        }
-        else 
-        {
-            if (!source.loadFrom(sourceForm)) 
+        } else {
+            if (!source.loadFrom(sourceForm))
                 return false;
-            if (!loadColorMap()) 
+            if (!loadColorMap())
                 return false;
-            if ((cmFlags & 8) == 0) 
+            if ((cmFlags & 8) == 0)
                 setUpColorMasks();
             sourceX = checkIntOrFloatIfNil(bbPointers[8], 0);
-            sourceY = checkIntOrFloatIfNil(bbPointers[9], 0); }
-        if (!loadBBHalftoneForm(halftoneForm)) 
+            sourceY = checkIntOrFloatIfNil(bbPointers[9], 0);
+        }
+        if (!loadBBHalftoneForm(halftoneForm))
             return false;
-        if (!loadBBClipRect(bbPointers)) 
+        if (!loadBBClipRect(bbPointers))
             return false;
-        if (!success) 
+        if (!success)
             return false;
-        if (combinationRule == 30 || combinationRule == 31) 
-        {
-            if (argCount != 1) 
+        if (combinationRule == 30 || combinationRule == 31) {
+            if (argCount != 1)
                 return false; // alpha arg is required
             sourceAlpha = checkIntValue(vm.top());
-            if (!(sourceAlpha >= 0 && sourceAlpha <= 255)) 
-                return false; 
-            if (success) 
-                vm.pop(); 
+            if (!(sourceAlpha >= 0 && sourceAlpha <= 255))
+                return false;
+            if (success)
+                vm.pop();
         }
         // Intersect incoming clipRect with destForm bounds
-        if (clipX < 0) 
-        {
-            clipWidth += clipX; clipX = 0; 
+        if (clipX < 0) {
+            clipWidth += clipX;
+            clipX = 0;
         }
-        if (clipY < 0) 
-        {
-            clipHeight += clipY; clipY = 0; 
+        if (clipY < 0) {
+            clipHeight += clipY;
+            clipY = 0;
         }
-        if ((clipX + clipWidth) > dest.width) 
-        {
-            clipWidth = dest.width - clipX; 
+        if ((clipX + clipWidth) > dest.width) {
+            clipWidth = dest.width - clipX;
         }
-        if ((clipY + clipHeight) > dest.height) 
-        {
-            clipHeight = dest.height - clipY; 
+        if ((clipY + clipHeight) > dest.height) {
+            clipHeight = dest.height - clipY;
         }
-        destIsDisplay= destForm == displayForm;
-        return true; 
+        destIsDisplay = destForm == displayForm;
+        return true;
     }
-    
-    boolean ignoreSourceOrHalftone(Object formPointer) 
-    {
-        if (formPointer == vm.nilObj) 
+
+    boolean ignoreSourceOrHalftone(Object formPointer) {
+        if (formPointer == vm.nilObj)
             return true;
-        if (combinationRule == 0) 
+        if (combinationRule == 0)
             return true;
-        if (combinationRule == 5) 
+        if (combinationRule == 5)
             return true;
         if (combinationRule == 10)
             return true;
-        if (combinationRule == 15) 
+        if (combinationRule == 15)
             return true;
-        return false; 
+        return false;
     }
- 
-    int checkIntValue(Object obj) 
-    {
+
+    int checkIntValue(Object obj) {
         if (SqueakVM.isSmallInt(obj))
-			return SqueakVM.intFromSmall(((Integer)obj));
-        success= false; 
-        return 0; 
+            return SqueakVM.intFromSmall(((Integer) obj));
+        success = false;
+        return 0;
     }
-    
-    int checkIntOrFloatIfNil(Object intOrFloatObj, int valueIfNil) 
-    {
+
+    int checkIntOrFloatIfNil(Object intOrFloatObj, int valueIfNil) {
         double floatValue;
         if (SqueakVM.isSmallInt(intOrFloatObj))
-			return SqueakVM.intFromSmall(((Integer)intOrFloatObj));
-        if (intOrFloatObj == vm.nilObj) 
+            return SqueakVM.intFromSmall(((Integer) intOrFloatObj));
+        if (intOrFloatObj == vm.nilObj)
             return valueIfNil;
-        SqueakObject floatObj= (SqueakObject) intOrFloatObj;
-        if (floatObj.sqClass!=vm.specialObjects[Squeak.splOb_ClassFloat]) 
-        {
-            success= false;
+        SqueakObject floatObj = (SqueakObject) intOrFloatObj;
+        if (floatObj.sqClass != vm.specialObjects[Squeak.splOb_ClassFloat]) {
+            success = false;
             return 0;
         }
         floatValue = floatObj.getFloatBits();
-        if (!((-2.147483648e9 <= floatValue) && (floatValue <= 2.147483647e9))) 
-        {
-            success= false; 
+        if (!((-2.147483648e9 <= floatValue) && (floatValue <= 2.147483647e9))) {
+            success = false;
             return 0;
         }
-        return ((int) floatValue); 
+        return ((int) floatValue);
     }
-    
+
     boolean loadBBHalftoneForm(Object aForm) // Not done yet!! 
-    { 
-        if (noHalftone) 
+    {
+        if (noHalftone)
             return true;
-        if (SqueakVM.isSmallInt(aForm)) 
+        if (SqueakVM.isSmallInt(aForm))
             return false;
-        if (((SqueakObject)aForm).format<6) 
-        {
+        if (((SqueakObject) aForm).format < 6) {
             //Old-style 32xN monochrome halftone Forms
-            Object[] formPointers = ((SqueakObject)aForm).pointers;
-            if (formPointers == null || formPointers.length<4)  
+            Object[] formPointers = ((SqueakObject) aForm).pointers;
+            if (formPointers == null || formPointers.length < 4)
                 return false;
             halftoneHeight = checkIntValue(formPointers[2]);
             Object bitsObject = formPointers[0];
-            halftoneBits = (int[])((SqueakObject)bitsObject).bits;
-            if (halftoneBits == null) 
+            halftoneBits = (int[]) ((SqueakObject) bitsObject).bits;
+            if (halftoneBits == null)
                 return false;
-            if (!success || (halftoneHeight < 1)) 
-                return false; 
-        }
-        else
-        {
+            if (!success || (halftoneHeight < 1))
+                return false;
+        } else {
             //New spec accepts, basically, a word array
             if (((SqueakObject) aForm).format != 6)
                 return false;
@@ -263,9 +247,8 @@ public class BitBlt
         }
         return true;
     }
-    
-    boolean loadBBDestRect(Object[] bbPointers) 
-    {
+
+    boolean loadBBDestRect(Object[] bbPointers) {
         destX = checkIntOrFloatIfNil(bbPointers[4], 0);
         destY = checkIntOrFloatIfNil(bbPointers[5], 0);
         width = checkIntOrFloatIfNil(bbPointers[6], dest.width);
@@ -273,190 +256,153 @@ public class BitBlt
         return success;
     }
 
-    boolean loadBBClipRect(Object[] bbPointers) 
-    {
+    boolean loadBBClipRect(Object[] bbPointers) {
         clipX = checkIntOrFloatIfNil(bbPointers[10], 0);
         clipY = checkIntOrFloatIfNil(bbPointers[11], 0);
         clipWidth = checkIntOrFloatIfNil(bbPointers[12], dest.width);
         clipHeight = checkIntOrFloatIfNil(bbPointers[13], dest.height);
-        return success; 
+        return success;
     }
-    
-    boolean loadColorMap() 
-    {
+
+    boolean loadColorMap() {
         // Not yet implemented
-        return true; 
-    } 
-    
-    boolean setUpColorMasks()
-    {
+        return true;
+    }
+
+    boolean setUpColorMasks() {
         // Not yet implemented
-        return true; 
-    } 
-    
-    void clipRange() 
-    {
-        if (destX >= clipX) 
-        {
+        return true;
+    }
+
+    void clipRange() {
+        if (destX >= clipX) {
             sx = sourceX;
             dx = destX;
-            bbW = width; 
-        } 
-        else 
-        {
+            bbW = width;
+        } else {
             sx = sourceX + (clipX - destX);
             bbW = width - (clipX - destX);
-            dx = clipX; 
+            dx = clipX;
         }
         if ((dx + bbW) > (clipX + clipWidth))
             bbW -= (dx + bbW) - (clipX + clipWidth);
-        if (destY >= clipY) 
-        {
+        if (destY >= clipY) {
             sy = sourceY;
             dy = destY;
-            bbH = height; 
-        }
-        else 
-        {
+            bbH = height;
+        } else {
             sy = (sourceY + clipY) - destY;
             bbH = height - (clipY - destY);
-            dy = clipY; 
+            dy = clipY;
         }
         if ((dy + bbH) > (clipY + clipHeight))
             bbH -= (dy + bbH) - (clipY + clipHeight);
-        if (noSource) 
+        if (noSource)
             return;
-        if (sx < 0) 
-        {
+        if (sx < 0) {
             dx -= sx;
             bbW += sx;
-            sx = 0; 
+            sx = 0;
         }
         if ((sx + bbW) > source.width)
             bbW -= (sx + bbW) - source.width;
-        if (sy < 0) 
-        {
+        if (sy < 0) {
             dy -= sy;
             bbH += sy;
-            sy = 0; 
+            sy = 0;
         }
         if ((sy + bbH) > source.height)
-            bbH -= (sy + bbH) - source.height; 
+            bbH -= (sy + bbH) - source.height;
     }
-    
-    Rectangle copyBits() 
-    {
+
+    Rectangle copyBits() {
         // combines copyBits, copybitsLockedAndClipped, and performcopyLoop
         clipRange();
         if (bbW <= 0 || bbH <= 0) return null;
         destMaskAndPointerInit();
         bitCount = 0;
         /* Choose and perform the actual copy loop. */
-        if (noSource) 
-        {
+        if (noSource) {
             copyLoopNoSource();
-        }
-        else 
-        {
+        } else {
             checkSourceOverlap();
-            if ((source.depth != dest.depth) || ((cmFlags != 0) || (source.msb != dest.msb))) 
-            {
-                copyLoopPixMap(); 
-            }
-            else
-            {
+            if ((source.depth != dest.depth) || ((cmFlags != 0) || (source.msb != dest.msb))) {
+                copyLoopPixMap();
+            } else {
                 sourceSkewAndPointerInit();
-                copyLoop(); 
+                copyLoop();
             }
         }
-        if (!destIsDisplay) 
+        if (!destIsDisplay)
             return null;
-        if ((combinationRule == 22) || (combinationRule == 32)) 
+        if ((combinationRule == 22) || (combinationRule == 32))
             return null;
-        if (hDir > 0) 
-        {
+        if (hDir > 0) {
             affectedL = dx;
-            affectedR = dx + bbW; 
-        }
-        else 
-        {
+            affectedR = dx + bbW;
+        } else {
             affectedL = (dx - bbW) + 1;
-            affectedR = dx + 1; 
+            affectedR = dx + 1;
         }
-        if (vDir > 0) 
-        {
+        if (vDir > 0) {
             affectedT = dy;
-            affectedB = dy + bbH; 
-        }
-        else 
-        {
+            affectedB = dy + bbH;
+        } else {
             affectedT = (dy - bbH) + 1;
-            affectedB = dy + 1; 
+            affectedB = dy + 1;
         }
-        return new Rectangle(affectedL, affectedT, affectedR-affectedL, affectedB-affectedT); 
+        return new Rectangle(affectedL, affectedT, affectedR - affectedL, affectedB - affectedT);
     }
-    
-    void destMaskAndPointerInit() 
-    {
+
+    void destMaskAndPointerInit() {
         int pixPerM1;
         int endBits;
         int startBits;
         pixPerM1 = dest.pixPerWord - 1;  //Pix per word is power of two, so this makes a mask
         startBits = dest.pixPerWord - (dx & pixPerM1); //how many pixels in first word
         mask1 = dest.msb ? AllOnes >>> (32 - (startBits * dest.depth))
-                         : AllOnes << (32 - (startBits * dest.depth));
+                : AllOnes << (32 - (startBits * dest.depth));
         endBits = (((dx + bbW) - 1) & pixPerM1) + 1;
         mask2 = dest.msb ? AllOnes << (32 - (endBits * dest.depth))
-                         : AllOnes >>> (32 - (endBits * dest.depth));
-        if (bbW < startBits) 
-        { 
+                : AllOnes >>> (32 - (endBits * dest.depth));
+        if (bbW < startBits) {
             //start and end in same word, so merge masks
             mask1 = mask1 & mask2;
             mask2 = 0;
-            nWords = 1; 
-        }
-        else 
-        {
+            nWords = 1;
+        } else {
             nWords = (((bbW - startBits) + pixPerM1) / dest.pixPerWord) + 1;
         }
         hDir = vDir = 1; //defaults for no overlap with source
         destIndex = (dy * dest.pitch) + (dx / dest.pixPerWord); //both these in words, not bytes
-        destDelta = (dest.pitch * vDir) - (nWords * hDir); 
+        destDelta = (dest.pitch * vDir) - (nWords * hDir);
     }
-    
-    void checkSourceOverlap()
-    {
+
+    void checkSourceOverlap() {
         int t;
-        if ((sourceForm == destForm) && (dy >= sy)) 
-        {
-            if (dy > sy) 
-            {
+        if ((sourceForm == destForm) && (dy >= sy)) {
+            if (dy > sy) {
                 vDir = -1;
                 sy = (sy + bbH) - 1;
-                dy = (dy + bbH) - 1; 
-            }
-            else 
-            {
-                if ((dy == sy) && (dx > sx)) 
-                {
+                dy = (dy + bbH) - 1;
+            } else {
+                if ((dy == sy) && (dx > sx)) {
                     hDir = -1;
                     sx = (sx + bbW) - 1; //start at right
                     dx = (dx + bbW) - 1;
-                    if (nWords > 1) 
-                    {
+                    if (nWords > 1) {
                         t = mask1; //and fix up masks
                         mask1 = mask2;
-                        mask2 = t; 
+                        mask2 = t;
                     }
                 }
             }
             destIndex = (dy * dest.pitch) + (dx / dest.pixPerWord); //recompute since dx, dy change
-            destDelta = (dest.pitch * vDir) - (nWords * hDir); 
+            destDelta = (dest.pitch * vDir) - (nWords * hDir);
         }
     }
-    
-    void sourceSkewAndPointerInit() 
-    {
+
+    void sourceSkewAndPointerInit() {
         int pixPerM1;
         int dxLowBits;
         int dWid;
@@ -466,54 +412,45 @@ public class BitBlt
         dxLowBits = dx & pixPerM1;
         // check if need to preload buffer
         // (i.e., two words of source needed for first word of destination)
-        if (hDir > 0) 
-        {
+        if (hDir > 0) {
             dWid = ((bbW < (dest.pixPerWord - dxLowBits)) ? bbW : (dest.pixPerWord - dxLowBits));
-            preload = (sxLowBits + dWid) > pixPerM1; 
-        }
-        else
-        {
+            preload = (sxLowBits + dWid) > pixPerM1;
+        } else {
             dWid = ((bbW < (dxLowBits + 1)) ? bbW : (dxLowBits + 1));
-            preload = ((sxLowBits - dWid) + 1) < 0; 
+            preload = ((sxLowBits - dWid) + 1) < 0;
         }
         skew = (source.msb) ? (sxLowBits - dxLowBits) * dest.depth
-                            :(dxLowBits - sxLowBits) * dest.depth;
-        if (preload) 
-        {
-            if (skew < 0) 
+                : (dxLowBits - sxLowBits) * dest.depth;
+        if (preload) {
+            if (skew < 0)
                 skew += 32;
-            else 
-                skew -= 32; 
+            else
+                skew -= 32;
         }
         /* calculate increments from end of one line to start of next */
         sourceIndex = (sy * source.pitch) + (sx / (32 / source.depth));
         sourceDelta = (source.pitch * vDir) - (nWords * hDir);
-        if (preload) 
-            sourceDelta -= hDir; 
+        if (preload)
+            sourceDelta -= hDir;
     }
-    
-    int halftoneAt(int index) 
-    {
-        return halftoneBits[SqueakVM.mod(index,halftoneHeight)]; 
+
+    int halftoneAt(int index) {
+        return halftoneBits[SqueakVM.mod(index, halftoneHeight)];
     }
-    
-    int srcLongAt(int index)
-    {
-        return source.bits[index]; 
+
+    int srcLongAt(int index) {
+        return source.bits[index];
     }
-    
-    int dstLongAt(int index)
-    {
-        return dest.bits[index]; 
+
+    int dstLongAt(int index) {
+        return dest.bits[index];
     }
-    
-    void dstLongAtput(int index, int intToPut)
-    {
-        dest.bits[index]= intToPut; 
+
+    void dstLongAtput(int index, int intToPut) {
+        dest.bits[index] = intToPut;
     }
-    
-    void copyLoopNoSource() 
-    {
+
+    void copyLoopNoSource() {
         //  Faster copyLoop when source not used.  hDir and vDir are both
         //  positive, and perload and skew are unused
         int mergeWord;
@@ -521,57 +458,49 @@ public class BitBlt
         int i;
         int halftoneWord;
         int destWord;
-        
+
         halftoneWord = AllOnes;
-        for (i = 1; i <= bbH; i += 1) 
-        { 
+        for (i = 1; i <= bbH; i += 1) {
             // vertical loop
-            if (!noHalftone) 
+            if (!noHalftone)
                 halftoneWord = halftoneAt((dy + i) - 1);
             destMask = mask1; // First word in row is masked
             destWord = dstLongAt(destIndex);
             mergeWord = mergeFnwith(halftoneWord, destWord);
             destWord = (destMask & mergeWord) | (destWord & (~destMask));
             dstLongAtput(destIndex, destWord);
-            destIndex ++;
+            destIndex++;
             destMask = AllOnes;
             //The central horizontal loop requires no store masking */
-            if (combinationRule == 3) 
-            {
+            if (combinationRule == 3) {
                 destWord = halftoneWord;
                 // Store rule requires no dest merging
-                for (word = 2; word <= (nWords - 1); word += 1) 
-                {
+                for (word = 2; word <= (nWords - 1); word += 1) {
                     dstLongAtput(destIndex, destWord);
-                    destIndex ++; 
+                    destIndex++;
                 }
-            }
-            else 
-            {
-                for (word = 2; word <= (nWords - 1); word += 1) 
-                {
+            } else {
+                for (word = 2; word <= (nWords - 1); word += 1) {
                     destWord = dstLongAt(destIndex);
                     mergeWord = mergeFnwith(halftoneWord, destWord);
                     dstLongAtput(destIndex, mergeWord);
-                    destIndex ++; 
+                    destIndex++;
                 }
             }
-            if (nWords > 1) 
-            {
+            if (nWords > 1) {
                 //last word in row is masked
                 destMask = mask2;
                 destWord = dstLongAt(destIndex);
                 mergeWord = mergeFnwith(halftoneWord, destWord);
                 destWord = (destMask & mergeWord) | (destWord & (~destMask));
                 dstLongAtput(destIndex, destWord);
-                destIndex ++; 
+                destIndex++;
             }
-            destIndex += destDelta; 
+            destIndex += destDelta;
         }
     }
-    
-    void copyLoop() 
-    {
+
+    void copyLoop() {
         //This version of the inner loop assumes noSource = false.
         int mergeWord;
         int skewMask;
@@ -586,66 +515,49 @@ public class BitBlt
         int destWord;
         int hInc;
         int thisWord;
-        int sourceLimit= source.bits.length;
+        int sourceLimit = source.bits.length;
         hInc = hDir;
-        if (skew == -32) 
-        {
-            skew = unskew = skewMask = 0; 
-        }
-        else 
-        {
-            if (skew < 0) 
-            {
+        if (skew == -32) {
+            skew = unskew = skewMask = 0;
+        } else {
+            if (skew < 0) {
                 unskew = skew + 32;
-                skewMask = AllOnes << (0 - skew); 
-            }
-            else 
-            {
-                if (skew == 0) 
-                {
+                skewMask = AllOnes << (0 - skew);
+            } else {
+                if (skew == 0) {
                     unskew = 0;
-                    skewMask = AllOnes; 
-                }
-                else 
-                {
+                    skewMask = AllOnes;
+                } else {
                     unskew = skew - 32;
-                    skewMask = ( AllOnes) >>> skew; 
+                    skewMask = (AllOnes) >>> skew;
                 }
             }
         }
         notSkewMask = ~skewMask;
-        if (noHalftone) 
-        {
+        if (noHalftone) {
             halftoneWord = AllOnes;
-            halftoneHeight = 0; 
-        }
-        else 
-        {
-            halftoneWord = halftoneAt(0); 
+            halftoneHeight = 0;
+        } else {
+            halftoneWord = halftoneAt(0);
         }
         y = dy;
-        for (i = 1; i <= bbH; i += 1) 
-        {
-            if (halftoneHeight > 1) 
-            {
+        for (i = 1; i <= bbH; i += 1) {
+            if (halftoneHeight > 1) {
                 halftoneWord = halftoneAt(y);
-                y += vDir; 
+                y += vDir;
             }
-            if (preload) 
-            {
+            if (preload) {
                 prevWord = srcLongAt(sourceIndex);
-                sourceIndex += hInc; 
-            }
-            else 
-            {
-                prevWord = 0; 
+                sourceIndex += hInc;
+            } else {
+                prevWord = 0;
             }
             destMask = mask1;
             /* pick up next word */
             thisWord = srcLongAt(sourceIndex);
             sourceIndex += hInc;
             /* 32-bit rotate */
-            skewWord = (((unskew < 0) ? ( (prevWord & notSkewMask) >>> -unskew) : ( (prevWord & notSkewMask) << unskew))) | (((skew < 0) ? ( (thisWord & skewMask) >>> -skew) : ( (thisWord & skewMask) << skew)));
+            skewWord = (((unskew < 0) ? ((prevWord & notSkewMask) >>> -unskew) : ((prevWord & notSkewMask) << unskew))) | (((skew < 0) ? ((thisWord & skewMask) >>> -skew) : ((thisWord & skewMask) << skew)));
             prevWord = thisWord;
             destWord = dstLongAt(destIndex);
             mergeWord = mergeFnwith(skewWord & halftoneWord, destWord);
@@ -654,89 +566,73 @@ public class BitBlt
             //The central horizontal loop requires no store masking */
             destIndex += hInc;
             destMask = AllOnes;
-            if (combinationRule == 3) 
-            {
+            if (combinationRule == 3) {
                 //Store mode avoids dest merge function
-                if ((skew == 0) && (halftoneWord == AllOnes)) 
-                {
+                if ((skew == 0) && (halftoneWord == AllOnes)) {
                     //Non-skewed with no halftone
-                    if (hDir == -1) 
-                    {
-                        for (word = 2; word <= (nWords - 1); word += 1) 
-                        {
+                    if (hDir == -1) {
+                        for (word = 2; word <= (nWords - 1); word += 1) {
                             thisWord = srcLongAt(sourceIndex);
                             sourceIndex += hInc;
                             dstLongAtput(destIndex, thisWord);
                             destIndex += hInc;
                         }
-                    }
-                    else 
-                    {
-                        for (word = 2; word <= (nWords - 1); word += 1) 
-                        {
+                    } else {
+                        for (word = 2; word <= (nWords - 1); word += 1) {
                             dstLongAtput(destIndex, prevWord);
                             destIndex += hInc;
                             prevWord = srcLongAt(sourceIndex);
-                            sourceIndex += hInc; 
+                            sourceIndex += hInc;
                         }
                     }
-                }
-                else 
-                {
+                } else {
                     //skewed and/or halftoned
-                    for (word = 2; word <= (nWords - 1); word += 1) 
-                    {
+                    for (word = 2; word <= (nWords - 1); word += 1) {
                         thisWord = srcLongAt(sourceIndex);
                         sourceIndex += hInc;
                         /* 32-bit rotate */
-                        skewWord = (((unskew < 0) ? ( (prevWord & notSkewMask) >>> -unskew) : ( (prevWord & notSkewMask) << unskew))) | (((skew < 0) ? ( (thisWord & skewMask) >>> -skew) : ( (thisWord & skewMask) << skew)));
+                        skewWord = (((unskew < 0) ? ((prevWord & notSkewMask) >>> -unskew) : ((prevWord & notSkewMask) << unskew))) | (((skew < 0) ? ((thisWord & skewMask) >>> -skew) : ((thisWord & skewMask) << skew)));
                         prevWord = thisWord;
                         dstLongAtput(destIndex, skewWord & halftoneWord);
-                        destIndex += hInc; 
+                        destIndex += hInc;
                     }
                 }
-            }
-            else 
-            {
+            } else {
                 //Dest merging here...
-                for (word = 2; word <= (nWords - 1); word += 1) 
-                {
+                for (word = 2; word <= (nWords - 1); word += 1) {
                     thisWord = srcLongAt(sourceIndex); //pick up next word
                     sourceIndex += hInc;
                     /* 32-bit rotate */
-                    skewWord = (((unskew < 0) ? ( (prevWord & notSkewMask) >>> -unskew) : ( (prevWord & notSkewMask) << unskew))) | (((skew < 0) ? ( (thisWord & skewMask) >>> -skew) : ( (thisWord & skewMask) << skew)));
+                    skewWord = (((unskew < 0) ? ((prevWord & notSkewMask) >>> -unskew) : ((prevWord & notSkewMask) << unskew))) | (((skew < 0) ? ((thisWord & skewMask) >>> -skew) : ((thisWord & skewMask) << skew)));
                     prevWord = thisWord;
                     mergeWord = mergeFnwith(skewWord & halftoneWord, dstLongAt(destIndex));
                     dstLongAtput(destIndex, mergeWord);
-                    destIndex += hInc; 
+                    destIndex += hInc;
                 }
             }
-            if (nWords > 1) 
-            {
+            if (nWords > 1) {
                 // last word with masking and all
                 destMask = mask2;
-                if (sourceIndex>=0 && sourceIndex<sourceLimit)
-                {
+                if (sourceIndex >= 0 && sourceIndex < sourceLimit) {
                     //NOTE: we are currently overrunning source bits in some cases
                     //this test makes up for it.
                     thisWord = srcLongAt(sourceIndex); //pick up next word
                 }
                 sourceIndex += hInc;
                 /* 32-bit rotate */
-                skewWord = (((unskew < 0) ? ((prevWord & notSkewMask) >>> -unskew) : ((prevWord & notSkewMask) << unskew))) | (((skew < 0) ? ( (thisWord & skewMask) >>> -skew) : ( (thisWord & skewMask) << skew)));
+                skewWord = (((unskew < 0) ? ((prevWord & notSkewMask) >>> -unskew) : ((prevWord & notSkewMask) << unskew))) | (((skew < 0) ? ((thisWord & skewMask) >>> -skew) : ((thisWord & skewMask) << skew)));
                 destWord = dstLongAt(destIndex);
                 mergeWord = mergeFnwith(skewWord & halftoneWord, destWord);
                 destWord = (destMask & mergeWord) | (destWord & (~destMask));
                 dstLongAtput(destIndex, destWord);
-                destIndex += hInc; 
+                destIndex += hInc;
             }
             sourceIndex += sourceDelta;
-            destIndex += destDelta; 
+            destIndex += destDelta;
         }
     }
 
-    void copyLoopPixMap() 
-    {
+    void copyLoopPixMap() {
         /*  This version of the inner loop maps source pixels
             to a destination form with different depth.  Because it is already
             unweildy, the loop is not unrolled as in the other versions.
@@ -784,19 +680,16 @@ public class BitBlt
         srcShiftInc = source.depth;
         dstShiftInc = dest.depth;
         dstShiftLeft = 0;
-        if (source.msb) 
-        {
+        if (source.msb) {
             srcShift = (32 - source.depth) - srcShift;
-            srcShiftInc = 0 - srcShiftInc; 
+            srcShiftInc = 0 - srcShiftInc;
         }
-        if (dest.msb) 
-        {
+        if (dest.msb) {
             dstShift = (32 - dest.depth) - dstShift;
             dstShiftInc = 0 - dstShiftInc;
-            dstShiftLeft = 32 - dest.depth; 
+            dstShiftLeft = 32 - dest.depth;
         }
-        for (i = 1; i <= bbH; i += 1) 
-        {
+        for (i = 1; i <= bbH; i += 1) {
             halftoneWord = (noHalftone) ? AllOnes : halftoneAt((dy + i) - 1);
             srcBitShift = srcShift;
             dstBitShift = dstShift;
@@ -804,45 +697,37 @@ public class BitBlt
             nPix = startBits;
             words = nWords;
             /* Here is the horizontal loop... */
-            do 
-            {
+            do {
                 /* align next word to leftmost pixel */
                 skewWord = pickSourcePixelsflagssrcMaskdestMasksrcShiftIncdstShiftInc(nPix, mapperFlags, sourcePixMask, destPixMask, srcShiftInc, dstShiftInc);
                 dstBitShift = dstShiftLeft;
-                if (destMask == AllOnes) 
-                {
+                if (destMask == AllOnes) {
                     mergeWord = mergeFnwith(skewWord & halftoneWord, dstLongAt(destIndex));
                     dstLongAtput(destIndex, destMask & mergeWord);
-                }
-                else 
-                {
+                } else {
                     destWord = dstLongAt(destIndex);
                     mergeWord = mergeFnwith(skewWord & halftoneWord, destWord & destMask);
                     destWord = (destMask & mergeWord) | (destWord & (~destMask));
-                    dstLongAtput(destIndex, destWord); 
+                    dstLongAtput(destIndex, destWord);
                 }
-                destIndex ++;
-                if (words == 2) 
-                {
+                destIndex++;
+                if (words == 2) {
                     destMask = mask2;
-                    nPix = endBits; 
-                }
-                else 
-                {
+                    nPix = endBits;
+                } else {
                     destMask = AllOnes;
-                    nPix = dest.pixPerWord; 
+                    nPix = dest.pixPerWord;
                 }
-            } while(!((words -= 1) == 0));
+            } while (!((words -= 1) == 0));
             sourceIndex += sourceDelta;
-            destIndex += destDelta; 
+            destIndex += destDelta;
         }
     }
-    
+
     //    int pickSourcePixelsflagssrcMaskdestMasksrcShiftIncdstShiftInc(int nPix, int mapperFlags, int sourcePixMask, int destPixMask, int srcShiftInc, int dstShiftInc) {
     //                return 0; }  //dummy stub for now
-    
-    int pickSourcePixelsflagssrcMaskdestMasksrcShiftIncdstShiftInc(int nPixels, int mapperFlags, int srcMask, int dstMask, int srcShiftInc, int dstShiftInc) 
-    {
+
+    int pickSourcePixelsflagssrcMaskdestMasksrcShiftIncdstShiftInc(int nPixels, int mapperFlags, int srcMask, int dstMask, int srcShiftInc, int dstShiftInc) {
         /*  Pick nPix pixels starting at srcBitIndex from the source, map by the
             color map, and justify them according to dstBitIndex in the resulting destWord. */
         int sourcePix;
@@ -858,149 +743,152 @@ public class BitBlt
         dstShift = dstBitShift;
         nPix = nPixels;
         /* always > 0 so we can use do { } while(--nPix); */
-        if (mapperFlags == (1 | 4)) 
-        {
-            do 
-            {
+        if (mapperFlags == (1 | 4)) {
+            do {
                 sourcePix = (sourceWord >>> srcShift) & srcMask;
                 destPix = cmLookupTable[sourcePix & cmMask];
                 /* adjust dest pix index */
                 destWord = destWord | ((destPix & dstMask) << dstShift);
                 /* adjust source pix index */
                 dstShift += dstShiftInc;
-                if (!(((srcShift += srcShiftInc) & AllOnes) == 0)) 
-                {
-                    if (source.msb) 
-                    {
-                        srcShift += 32; 
+                if (!(((srcShift += srcShiftInc) & AllOnes) == 0)) {
+                    if (source.msb) {
+                        srcShift += 32;
+                    } else {
+                        srcShift -= 32;
                     }
-                    else 
-                    {
-                        srcShift -= 32; 
-                    }
-                    sourceWord = srcLongAt(sourceIndex += 4); 
+                    sourceWord = srcLongAt(sourceIndex += 4);
                 }
-            } while(!((nPix -= 1) == 0)); } /*clean double-neg here*/
-        else 
-        {
-            do 
-            {
+            } while (!((nPix -= 1) == 0));
+        } /*clean double-neg here*/ else {
+            do {
                 sourcePix = (sourceWord >>> srcShift) & srcMask;
                 destPix = mapPixelflags(sourcePix, mapperFlags);
                 /* adjust dest pix index */
                 destWord = destWord | ((destPix & dstMask) << dstShift);
                 /* adjust source pix index */
                 dstShift += dstShiftInc;
-                if (!(((srcShift += srcShiftInc) & AllOnes) == 0)) 
-                {
-                    if (source.msb) 
-                    {
-                        srcShift += 32; 
+                if (!(((srcShift += srcShiftInc) & AllOnes) == 0)) {
+                    if (source.msb) {
+                        srcShift += 32;
+                    } else {
+                        srcShift -= 32;
                     }
-                    else 
-                    {
-                        srcShift -= 32; 
-                    }
-                    sourceWord = srcLongAt(sourceIndex += 1); 
+                    sourceWord = srcLongAt(sourceIndex += 1);
                 }
-            } while(!((nPix -= 1) == 0));  /*clean double-neg here*/
+            } while (!((nPix -= 1) == 0));  /*clean double-neg here*/
         }
         /* Store back */
         srcBitShift = srcShift;
-        return destWord; 
+        return destWord;
     }
 
     /*  Color map the given source pixel. */
-    
-    int mapPixelflags(int sourcePixel, int mapperFlags) 
-    {
+
+    int mapPixelflags(int sourcePixel, int mapperFlags) {
         int pv;
         pv = sourcePixel;
-        if ((mapperFlags & 1) != 0) 
-        {
-            if ((mapperFlags & 2) != 0) 
-            {
+        if ((mapperFlags & 1) != 0) {
+            if ((mapperFlags & 2) != 0) {
                 /* avoid introducing transparency by color reduction */
                 pv = rgbMapPixelflags(sourcePixel, mapperFlags);
-                if ((pv == 0) && (sourcePixel != 0)) 
-                {
-                    pv = 1; 
+                if ((pv == 0) && (sourcePixel != 0)) {
+                    pv = 1;
                 }
             }
-            if ((mapperFlags & 4) != 0) 
-            {
-                pv = cmLookupTable[pv & cmMask]; 
+            if ((mapperFlags & 4) != 0) {
+                pv = cmLookupTable[pv & cmMask];
             }
         }
-        return pv; 
+        return pv;
     }
-    
-    int rgbMapPixelflags(int sourcePixel, int mapperFlags) 
-    {
-        int val =     (cmShiftTable[0] < 0) ? (sourcePixel & cmMaskTable[0]) >>> -(cmShiftTable[0]) : (sourcePixel & cmMaskTable[0]) << (cmShiftTable[0]);
-        val = val |  ((cmShiftTable[1] < 0) ? (sourcePixel & cmMaskTable[1]) >>> -(cmShiftTable[1]) : (sourcePixel & cmMaskTable[1]) << (cmShiftTable[1]));
-        val = val |  ((cmShiftTable[2] < 0) ? (sourcePixel & cmMaskTable[2]) >>> -(cmShiftTable[2]) : (sourcePixel & cmMaskTable[2]) << (cmShiftTable[2]));
+
+    int rgbMapPixelflags(int sourcePixel, int mapperFlags) {
+        int val = (cmShiftTable[0] < 0) ? (sourcePixel & cmMaskTable[0]) >>> -(cmShiftTable[0]) : (sourcePixel & cmMaskTable[0]) << (cmShiftTable[0]);
+        val = val | ((cmShiftTable[1] < 0) ? (sourcePixel & cmMaskTable[1]) >>> -(cmShiftTable[1]) : (sourcePixel & cmMaskTable[1]) << (cmShiftTable[1]));
+        val = val | ((cmShiftTable[2] < 0) ? (sourcePixel & cmMaskTable[2]) >>> -(cmShiftTable[2]) : (sourcePixel & cmMaskTable[2]) << (cmShiftTable[2]));
         return val | ((cmShiftTable[3] < 0) ? (sourcePixel & cmMaskTable[3]) >>> -(cmShiftTable[3]) : (sourcePixel & cmMaskTable[3]) << (cmShiftTable[3]));
     }
 
 
-    int mergeFnwith(int sourceWord, int destinationWord) 
-    {
-        switch (combinationRule) 
-        {
-            case 0: return 0;
-            case 1: return sourceWord & destinationWord;
-            case 2: return sourceWord & (~destinationWord);
-            case 3: return sourceWord;
-            case 4: return (~sourceWord) & destinationWord;
-            case 5: return destinationWord;
-            case 6: return sourceWord ^ destinationWord;
-            case 7: return sourceWord | destinationWord;
-            case 8: return (~sourceWord) & (~destinationWord);
-            case 9: return (~sourceWord) ^ destinationWord;
-            case 10: return ~destinationWord;
-            case 11: return sourceWord | (~destinationWord);
-            case 12: return ~sourceWord;
-            case 13: return (~sourceWord) | destinationWord;
-            case 14: return (~sourceWord) | (~destinationWord);
-            case 15: return destinationWord;
-            case 16: return destinationWord;
-            case 17: return destinationWord;
-            case 18: return sourceWord + destinationWord;
-            case 19: return sourceWord - destinationWord;
-            case 20: return sourceWord;
-            case 21: return sourceWord;
-            case 22: return sourceWord;
-            case 23: return sourceWord;
-            case 24: return sourceWord;
-            case 25: 
-            { 
+    int mergeFnwith(int sourceWord, int destinationWord) {
+        switch (combinationRule) {
+            case 0:
+                return 0;
+            case 1:
+                return sourceWord & destinationWord;
+            case 2:
+                return sourceWord & (~destinationWord);
+            case 3:
+                return sourceWord;
+            case 4:
+                return (~sourceWord) & destinationWord;
+            case 5:
+                return destinationWord;
+            case 6:
+                return sourceWord ^ destinationWord;
+            case 7:
+                return sourceWord | destinationWord;
+            case 8:
+                return (~sourceWord) & (~destinationWord);
+            case 9:
+                return (~sourceWord) ^ destinationWord;
+            case 10:
+                return ~destinationWord;
+            case 11:
+                return sourceWord | (~destinationWord);
+            case 12:
+                return ~sourceWord;
+            case 13:
+                return (~sourceWord) | destinationWord;
+            case 14:
+                return (~sourceWord) | (~destinationWord);
+            case 15:
+                return destinationWord;
+            case 16:
+                return destinationWord;
+            case 17:
+                return destinationWord;
+            case 18:
+                return sourceWord + destinationWord;
+            case 19:
+                return sourceWord - destinationWord;
+            case 20:
+                return sourceWord;
+            case 21:
+                return sourceWord;
+            case 22:
+                return sourceWord;
+            case 23:
+                return sourceWord;
+            case 24:
+                return sourceWord;
+            case 25: {
                 if (sourceWord == 0)
                     return destinationWord;
-                return sourceWord | (partitionedANDtonBitsnPartitions(~sourceWord, destinationWord, dest.depth, dest.pixPerWord)); 
+                return sourceWord | (partitionedANDtonBitsnPartitions(~sourceWord, destinationWord, dest.depth, dest.pixPerWord));
             }
-            case 26: return partitionedANDtonBitsnPartitions(~sourceWord, destinationWord, dest.depth, dest.pixPerWord);
-            default: return sourceWord; 
+            case 26:
+                return partitionedANDtonBitsnPartitions(~sourceWord, destinationWord, dest.depth, dest.pixPerWord);
+            default:
+                return sourceWord;
         }
     }
 
-    static int partitionedANDtonBitsnPartitions(int word1, int word2, int nBits, int nParts) 
-    {
+    static int partitionedANDtonBitsnPartitions(int word1, int word2, int nBits, int nParts) {
         int i;
         int result;
         int mask;
         /* partition mask starts at the right */
         mask = maskTable[nBits];
         result = 0;
-        for (i = 1; i <= nParts; i += 1) 
-        {
-            if ((word1 & mask) == mask) 
-            {
-                result = result | (word2 & mask); 
+        for (i = 1; i <= nParts; i += 1) {
+            if ((word1 & mask) == mask) {
+                result = result | (word2 & mask);
             }
             /* slide left to next partition */
-            mask = mask << nBits; 
+            mask = mask << nBits;
         }
-        return result; 
+        return result;
     }
 }

--- a/src/JSqueak/FileSystemPrimitives.java
+++ b/src/JSqueak/FileSystemPrimitives.java
@@ -9,487 +9,442 @@ import java.util.Map;
 
 /**
  * The methods in this class implement the following file system primitives:
- *
- *    "File Primitives (150-169)"
- *    (150 primitiveFileAtEnd)
- *    (151 primitiveFileClose)
- *    (152 primitiveFileGetPosition)
- *    (153 primitiveFileOpen)
- *    (154 primitiveFileRead)
- *    (155 primitiveFileSetPosition)
- *    (156 primitiveFileDelete)
- *    (157 primitiveFileSize)
- *    (158 primitiveFileWrite)
- *    (159 primitiveFileRename)
- *    (160 primitiveDirectoryCreate)
- *    (161 primitiveDirectoryDelimitor)
- *    (162 primitiveDirectoryLookup)
- *
- *
+ * <p>
+ * "File Primitives (150-169)"
+ * (150 primitiveFileAtEnd)
+ * (151 primitiveFileClose)
+ * (152 primitiveFileGetPosition)
+ * (153 primitiveFileOpen)
+ * (154 primitiveFileRead)
+ * (155 primitiveFileSetPosition)
+ * (156 primitiveFileDelete)
+ * (157 primitiveFileSize)
+ * (158 primitiveFileWrite)
+ * (159 primitiveFileRename)
+ * (160 primitiveDirectoryCreate)
+ * (161 primitiveDirectoryDelimitor)
+ * (162 primitiveDirectoryLookup)
+ * <p>
+ * <p>
  * The primitive method comments were mostly taken from a Squeak 1.1 image, with one
  * or two coming from a Squeak 3.9 image.
- * 
+ * <p>
  * Known issues and todo items:
- *
- *    * Lightly tested, use at your own risk!
- *    
- *    * Files are kept in a map, and they are never removed from it (so they are
- *      not being garbage collected.
- *
- *    * Unsure what to return from fileClose(), assuming self (at least that is what Squeak 3.9 does).
- *    
- *    * Unsure what to return from fileRename() and directoryCreate().  Assuming self.
- *
- *    * Cannot yet handle non-small integers.  This affects the following methods:
- *
- *      * getPosition()
- *      * readIntoStartingAtCount()
- *      * fileSize()
- *      * fileWrite()
- *
- *    * Cannot handle non-byte arrays.  This affects the methods:
- *
- *      * readIntoStartingAtCount()
- *      * fileWrite()
- *      
- *    * Debug logging (printing stack traces) needs to be cleaned up.
+ * <p>
+ * * Lightly tested, use at your own risk!
+ * <p>
+ * * Files are kept in a map, and they are never removed from it (so they are
+ * not being garbage collected.
+ * <p>
+ * * Unsure what to return from fileClose(), assuming self (at least that is what Squeak 3.9 does).
+ * <p>
+ * * Unsure what to return from fileRename() and directoryCreate().  Assuming self.
+ * <p>
+ * * Cannot yet handle non-small integers.  This affects the following methods:
+ * <p>
+ * * getPosition()
+ * * readIntoStartingAtCount()
+ * * fileSize()
+ * * fileWrite()
+ * <p>
+ * * Cannot handle non-byte arrays.  This affects the methods:
+ * <p>
+ * * readIntoStartingAtCount()
+ * * fileWrite()
+ * <p>
+ * * Debug logging (printing stack traces) needs to be cleaned up.
  */
-class FileSystemPrimitives 
-{
+public class FileSystemPrimitives {
     private final SqueakPrimitiveHandler fHandler;
-    
+
     /**
      * Map<SqueakObject, RandomAccessFile> of files keyed by ID (Squeak String).
      */
     private final Map fFiles = new HashMap();
-    
-    public FileSystemPrimitives( SqueakPrimitiveHandler primitiveHandler )
-    {
-        fHandler = primitiveHandler;
-    }    
 
-    
+    public FileSystemPrimitives(SqueakPrimitiveHandler primitiveHandler) {
+        fHandler = primitiveHandler;
+    }
+
+
     // -- Primitives ----------------------------------------------------------------------
 
-    
+
     /**
      * primAtEnd: id
-     *    "Answer whether the receiver is currently at its end.  2/12/96 sw"
-     *
-     *    <primitive: 150>
-     *    ^ self primitiveFailed!
+     * "Answer whether the receiver is currently at its end.  2/12/96 sw"
+     * <p>
+     * <primitive: 150>
+     * ^ self primitiveFailed!
      */
-    Object fileAtEnd( int argCount )
-    {
-        if ( argCount != 1 )
+    Object fileAtEnd(int argCount) {
+        if (argCount != 1)
             throw fHandler.primitiveFailed();
-        
+
         RandomAccessFile file = lookupFile();
-        try 
-        {
-            return fHandler.squeakBool( file.getFilePointer() >= file.length() );
-        }
-        catch ( IOException e ) 
-        {
+        try {
+            return fHandler.squeakBool(file.getFilePointer() >= file.length());
+        } catch (IOException e) {
             e.printStackTrace();
         }
-        
+
         throw fHandler.primitiveFailed();
     }
 
     /**
-      * primClose: anID
-      *         "Primitive call to close the receiver.  2/12/96 sw"
-      *         <primitive: 151>
-      *         ^ self primitiveFailed!    
-      */
-    Object fileClose( int argCount )
-    {
-        if ( argCount != 1 )
+     * primClose: anID
+     * "Primitive call to close the receiver.  2/12/96 sw"
+     * <primitive: 151>
+     * ^ self primitiveFailed!
+     */
+    Object fileClose(int argCount) {
+        if (argCount != 1)
             throw fHandler.primitiveFailed();
-        
+
         RandomAccessFile file = lookupFile();
-        try 
-        {
+        try {
             file.close();
-            
+
             // Pharo seems to return self, so let's do the same
-            return fHandler.stackReceiver( 1 );
-        }
-        catch (IOException e) 
-        {
+            return fHandler.stackReceiver(1);
+        } catch (IOException e) {
             e.printStackTrace();
         }
-        
+
         throw fHandler.primitiveFailed();
     }
 
     /**
      * primGetPosition: id
-     *     "Get the receiver's current file position.  2/12/96 sw"
-     *     <primitive: 152>
-     *     ^ self primitiveFailed!
+     * "Get the receiver's current file position.  2/12/96 sw"
+     * <primitive: 152>
+     * ^ self primitiveFailed!
      */
-    Object getPosition( int argCount )
-    {
-        if ( argCount != 1 )
-            throw fHandler.primitiveFailed();
-        
-        RandomAccessFile file = lookupFile();
-        try 
-        {
-            return fHandler.pos32BitIntFor( file.getFilePointer() );
-        }
-        catch (IOException e) 
-        {
-            e.printStackTrace();
-        }
-        
-        throw fHandler.primitiveFailed();
-    }
-    
-    /**
-     * primOpen: fileName writable: writableFlag
-     *     "Open a file of the given name, and return the file ID obtained.
-     *     If writableFlag is true, then 
-     *         if there is none with this name, then create one
-     *         else prepare to overwrite the existing from the beginning
-     *     otherwise
-     *        if the file exists, open it read-only
-     *        else return nil"
-     *
-     *     <primitive: 153>
-     *     ^ nil
-     */
-    Object openWritable( int argCount ) 
-    {
-        if ( argCount != 2 )
+    Object getPosition(int argCount) {
+        if (argCount != 1)
             throw fHandler.primitiveFailed();
 
-        SqueakObject fileName = fHandler.stackNonInteger( 1 );
-        SqueakObject writableFlag = fHandler.stackNonInteger( 0 );
-        
-        String mode = fHandler.javaBool( writableFlag ) ? "rw" : "r";
-        try 
-        {
-            RandomAccessFile file = new RandomAccessFile( fileName.asString(), mode );
-            SqueakObject fileId = fHandler.makeStString( "fileId: " + fileName.asString() );
-            setFile( fileId, file );
-            
-            return fileId; 
+        RandomAccessFile file = lookupFile();
+        try {
+            return fHandler.pos32BitIntFor(file.getFilePointer());
+        } catch (IOException e) {
+            e.printStackTrace();
         }
-        catch (  FileNotFoundException e ) 
-        {
-            System.err.println( e.getMessage() );
+
+        throw fHandler.primitiveFailed();
+    }
+
+    /**
+     * primOpen: fileName writable: writableFlag
+     * "Open a file of the given name, and return the file ID obtained.
+     * If writableFlag is true, then
+     * if there is none with this name, then create one
+     * else prepare to overwrite the existing from the beginning
+     * otherwise
+     * if the file exists, open it read-only
+     * else return nil"
+     * <p>
+     * <primitive: 153>
+     * ^ nil
+     */
+    Object openWritable(int argCount) {
+        if (argCount != 2)
+            throw fHandler.primitiveFailed();
+
+        SqueakObject fileName = fHandler.stackNonInteger(1);
+        SqueakObject writableFlag = fHandler.stackNonInteger(0);
+
+        String mode = fHandler.javaBool(writableFlag) ? "rw" : "r";
+        try {
+            RandomAccessFile file = new RandomAccessFile(fileName.asString(), mode);
+            SqueakObject fileId = fHandler.makeStString("fileId: " + fileName.asString());
+            setFile(fileId, file);
+
+            return fileId;
+        } catch (FileNotFoundException e) {
+            System.err.println(e.getMessage());
         }
-        
+
         throw fHandler.primitiveFailed();
     }
 
     /**
      * primRead: id into: byteArray startingAt: startIndex count: count
-     *    "read from the receiver's file into the given area of storage, starting at the given index, 
-     *    as many as count bytes; return the number of bytes actually read.  2/12/96 sw"
-     *
-     *    <primitive: 154>
-     *
-     *    self halt: 'error reading file'!
+     * "read from the receiver's file into the given area of storage, starting at the given index,
+     * as many as count bytes; return the number of bytes actually read.  2/12/96 sw"
+     * <p>
+     * <primitive: 154>
+     * <p>
+     * self halt: 'error reading file'!
      */
-    Object readIntoStartingAtCount( int argCount )
-    {
-        if ( argCount != 4 )
+    Object readIntoStartingAtCount(int argCount) {
+        if (argCount != 4)
             throw fHandler.primitiveFailed();
-        
-        SqueakObject byteArray = fHandler.stackNonInteger( 2 );
-        int startIndex = fHandler.stackInteger( 1 ) - 1;
-        int count = fHandler.stackInteger( 0 );
-        
-        RandomAccessFile file = lookupFile( 3 );
-        
-        byte[] buffer = new byte[ count ];
-        try 
-        {
-            int read = file.read( buffer, 0, count );
-            
-            for ( int index = 0; index < read; index++ )
-            {
-                byteArray.setByte( startIndex + index, buffer[index] ); // FIXME: this code cheats!
+
+        SqueakObject byteArray = fHandler.stackNonInteger(2);
+        int startIndex = fHandler.stackInteger(1) - 1;
+        int count = fHandler.stackInteger(0);
+
+        RandomAccessFile file = lookupFile(3);
+
+        byte[] buffer = new byte[count];
+        try {
+            int read = file.read(buffer, 0, count);
+
+            for (int index = 0; index < read; index++) {
+                byteArray.setByte(startIndex + index, buffer[index]); // FIXME: this code cheats!
             }
-            
-            return fHandler.pos32BitIntFor( read );
-        } 
-        catch ( IOException e ) 
-        {
+
+            return fHandler.pos32BitIntFor(read);
+        } catch (IOException e) {
             e.printStackTrace();
         }
-	
+
         throw fHandler.primitiveFailed();
     }
 
     /**
      * primSetPosition: id to: aNumber
-     *     "Set the receiver's file position to be a Number.  2/12/96 sw"
-     *     <primitive: 155>
-     *     ^ self primitiveFailed!
+     * "Set the receiver's file position to be a Number.  2/12/96 sw"
+     * <primitive: 155>
+     * ^ self primitiveFailed!
      */
-    Object fileSetPosition( int argCount ) 
-    {
-        if ( argCount != 2 )
+    Object fileSetPosition(int argCount) {
+        if (argCount != 2)
             throw fHandler.primitiveFailed();
-        
-        RandomAccessFile file = lookupFile( 1 );
-        int pos = fHandler.stackPos32BitValue( 0 );
-            
-        try 
-        {
-            file.seek( pos );
-            return fHandler.stackReceiver( argCount );
-        }
-        catch (IOException e) 
-        {
+
+        RandomAccessFile file = lookupFile(1);
+        int pos = fHandler.stackPos32BitValue(0);
+
+        try {
+            file.seek(pos);
+            return fHandler.stackReceiver(argCount);
+        } catch (IOException e) {
             e.printStackTrace();
         }
-	
+
         throw fHandler.primitiveFailed();
     }
 
     /**
      * primDeleteFileNamed: aFileName
-     *     "Delete the file of the given name. Return self if the primitive succeeds, nil otherwise."
-     *     
-     *     <primitive: 156>
-     *     ^ nil
+     * "Delete the file of the given name. Return self if the primitive succeeds, nil otherwise."
+     * <p>
+     * <primitive: 156>
+     * ^ nil
      */
-    Object fileDelete(int argCount) 
-    {
-        if ( argCount != 1 )
+    Object fileDelete(int argCount) {
+        if (argCount != 1)
             throw fHandler.primitiveFailed();
-        
-        SqueakObject fileName = fHandler.stackNonInteger( 0 );
-        
-        File file = new File( fileName.asString() );
-        if ( file.delete() )
-            return fHandler.stackReceiver( argCount ); 
-        
+
+        SqueakObject fileName = fHandler.stackNonInteger(0);
+
+        File file = new File(fileName.asString());
+        if (file.delete())
+            return fHandler.stackReceiver(argCount);
+
         throw fHandler.primitiveFailed();
     }
 
     /**
      * primSize: id
-     *    "Return the size of the receiver's file.  2/12/96 sw"
-     *    <primitive: 157>
-     *    ^ self primitiveFailed!
+     * "Return the size of the receiver's file.  2/12/96 sw"
+     * <primitive: 157>
+     * ^ self primitiveFailed!
      */
-    Object fileSize(int argCount) 
-    {
-        if ( argCount != 1 )
+    Object fileSize(int argCount) {
+        if (argCount != 1)
             throw fHandler.primitiveFailed();
-        
+
         RandomAccessFile file = lookupFile();
-        try 
-        {
-            return fHandler.pos32BitIntFor( file.length() );
-        }
-        catch ( IOException e ) 
-        {
+        try {
+            return fHandler.pos32BitIntFor(file.length());
+        } catch (IOException e) {
             e.printStackTrace();
         }
-	
+
         throw fHandler.primitiveFailed();
     }
 
     /**
      * primWrite: id from: byteArray startingAt: startIndex count: count
-     *     "Write into the receiver's file from the given area of storage, starting 
-     *     at the given index, as many as count bytes; return the number of bytes 
-     *     actually written. 2/12/96 sw"
-     *     
-     *     <primitive: 158>
-     *     
-     *     closed ifTrue: [^ self halt: 'Write error: File not open'].
-     *     rwmode ifFalse: [^ self halt: 'Error-attempt to write to a read-only file.'].
-     *     self halt: 'File write error'! !
+     * "Write into the receiver's file from the given area of storage, starting
+     * at the given index, as many as count bytes; return the number of bytes
+     * actually written. 2/12/96 sw"
+     * <p>
+     * <primitive: 158>
+     * <p>
+     * closed ifTrue: [^ self halt: 'Write error: File not open'].
+     * rwmode ifFalse: [^ self halt: 'Error-attempt to write to a read-only file.'].
+     * self halt: 'File write error'! !
      */
-    Object fileWrite (int argCount ) 
-    {
-        if ( argCount != 4 )
+    Object fileWrite(int argCount) {
+        if (argCount != 4)
             throw fHandler.primitiveFailed();
-        
-        RandomAccessFile file = lookupFile( 3 );
-        SqueakObject byteArray = fHandler.stackNonInteger( 2 );
-        int startIndex = fHandler.stackInteger( 1 ) - 1; // zero based
-        int count = fHandler.stackInteger( 0 );
-        
-        try 
-        {
+
+        RandomAccessFile file = lookupFile(3);
+        SqueakObject byteArray = fHandler.stackNonInteger(2);
+        int startIndex = fHandler.stackInteger(1) - 1; // zero based
+        int count = fHandler.stackInteger(0);
+
+        try {
             int written = 0;
-            for ( int index = startIndex; index < startIndex + count; index++ )
-            {
-                file.write( byteArray.getByte( index ) );
+            for (int index = startIndex; index < startIndex + count; index++) {
+                file.write(byteArray.getByte(index));
                 written++;
             }
-            
-            return fHandler.pos32BitIntFor( written );
-        }
-        catch ( IOException e ) 
-        {
+
+            return fHandler.pos32BitIntFor(written);
+        } catch (IOException e) {
             e.printStackTrace();
         }
-        
+
         throw fHandler.primitiveFailed();
     }
 
 
     /**
-     * primitiveRename: oldFileName toBe: newFileName 
-     *     "Rename the file of the given name if it exists, else fail"
-     *     <primitive: 159>
-     *     self halt: 'Attempt to rename a non-existent file,
-     *     or to use a name that is already in use'!
+     * primitiveRename: oldFileName toBe: newFileName
+     * "Rename the file of the given name if it exists, else fail"
+     * <primitive: 159>
+     * self halt: 'Attempt to rename a non-existent file,
+     * or to use a name that is already in use'!
      */
-    Object fileRename( int argCount ) 
-    {
-        if ( argCount != 2 )
+    Object fileRename(int argCount) {
+        if (argCount != 2)
             throw fHandler.primitiveFailed();
-        
-        SqueakObject oldName = fHandler.stackNonInteger( 1 );
-        SqueakObject newName = fHandler.stackNonInteger( 0 );
-        
-        File file = new File( oldName.asString() );
-        if ( file.renameTo( new File( newName.asString() ) ) )
-            return fHandler.stackReceiver( argCount ); 
-        
+
+        SqueakObject oldName = fHandler.stackNonInteger(1);
+        SqueakObject newName = fHandler.stackNonInteger(0);
+
+        File file = new File(oldName.asString());
+        if (file.renameTo(new File(newName.asString())))
+            return fHandler.stackReceiver(argCount);
+
         throw fHandler.primitiveFailed();
     }
 
     /**
      * primCreateDirectory: fullPath
-     *     "Create a directory named by the given path. Fail if the path 
-     *     is bad or if a file or directory by that name already exists."
-     * 
-     *     <primitive: 'primitiveDirectoryCreate' module: 'FilePlugin'>
-     *     self primitiveFailed
+     * "Create a directory named by the given path. Fail if the path
+     * is bad or if a file or directory by that name already exists."
+     * <p>
+     * <primitive: 'primitiveDirectoryCreate' module: 'FilePlugin'>
+     * self primitiveFailed
      */
-    Object directoryCreate( int argCount ) 
-    {
-        if ( argCount != 1 )
+    Object directoryCreate(int argCount) {
+        if (argCount != 1)
             throw fHandler.primitiveFailed();
-        
-        SqueakObject fullPath = fHandler.stackNonInteger( 0 );
-        
-        File directory = new File( fullPath.asString() );
-        if ( directory.mkdir() )
-            return fHandler.stackReceiver( argCount ); 
-        
+
+        SqueakObject fullPath = fHandler.stackNonInteger(0);
+
+        File directory = new File(fullPath.asString());
+        if (directory.mkdir())
+            return fHandler.stackReceiver(argCount);
+
         throw fHandler.primitiveFailed();
     }
 
     /**
      * actualPathNameDelimiter
-     *     "Return the path delimiter for the underlying file system."
-     *     <primitive: 161>
-     *     self primitiveFailed.!
+     * "Return the path delimiter for the underlying file system."
+     * <primitive: 161>
+     * self primitiveFailed.!
      */
-    SqueakObject directoryDelimitor()
-    {
-        return fHandler.charFromInt( (int) File.separatorChar );
+    SqueakObject directoryDelimitor() {
+        return fHandler.charFromInt((int) File.separatorChar);
     }
 
     /**
      * lookupEntryIn: pathName index: index
-     *     "Look up the index-th entry of the directory with the given path
-     *     (starting from the root of the file hierarchy) and return an array
-     *     containing:
-     *     
-     *     <name> <creationTime> <modificationTime> <dirFlag> <fileSize>
-     *     
-     *     The creation and modification times are in seconds since the start
-     *     of the Smalltalk time epoch. DirFlag is true if the entry is a
-     *     directory. FileSize the file size in bytes or zero for directories.
-     *     The primitive returns nil when index is past the end of the directory.
-     *     It fails if the given pathName is bad."
-     *     
-     *     <primitive: 162>
-     *     self primitiveFailed.!
+     * "Look up the index-th entry of the directory with the given path
+     * (starting from the root of the file hierarchy) and return an array
+     * containing:
+     *
+     * <name> <creationTime> <modificationTime> <dirFlag> <fileSize>
+     * <p>
+     * The creation and modification times are in seconds since the start
+     * of the Smalltalk time epoch. DirFlag is true if the entry is a
+     * directory. FileSize the file size in bytes or zero for directories.
+     * The primitive returns nil when index is past the end of the directory.
+     * It fails if the given pathName is bad."
+     * <p>
+     * <primitive: 162>
+     * self primitiveFailed.!
      */
-    Object lookupEntryInIndex( int argCount ) 
-    {
-        if ( argCount != 2 )
+    Object lookupEntryInIndex(int argCount) {
+        if (argCount != 2)
             throw fHandler.primitiveFailed();
-        
-        SqueakObject fullPath = fHandler.stackNonInteger( 1 );
-        int index = fHandler.stackInteger( 0 ) - 1;
-        
-        if ( index < 0 )
+
+        SqueakObject fullPath = fHandler.stackNonInteger(1);
+        int index = fHandler.stackInteger(0) - 1;
+
+        if (index < 0)
             throw fHandler.primitiveFailed();
-        
+
         String filename = fullPath.asString();
-        if ( filename.trim().length() == 0 )
+        if (filename.trim().length() == 0)
             filename = "/";
-        
-        File directory = new File( fullPath.asString() );
-        if ( ! directory.exists() )
+
+        File directory = new File(fullPath.asString());
+        if (!directory.exists())
             throw fHandler.primitiveFailed();
-        
+
         File[] paths = directory.listFiles();
-        if ( index < paths.length )
-            return makeDirectoryEntryArray( paths[index] );
-        
+        if (index < paths.length)
+            return makeDirectoryEntryArray(paths[index]);
+
         return fHandler.squeakNil();
     }
 
     /**
      * Array with
      *
-     *    <name> <creationTime> <modificationTime> <dirFlag> <fileSize>
-     *
+     * <name> <creationTime> <modificationTime> <dirFlag> <fileSize>
+     * <p>
      * See {@link #lookupEntryInIndex(int)}
      */
-    private SqueakObject makeDirectoryEntryArray( File file ) 
-    {
+    private SqueakObject makeDirectoryEntryArray(File file) {
         // bah, Java doesn't provide the creation time.  If it is
         // really necessary, it may be possible to use java-posix or
         // jtux.
         String name = file.getName();
-        long creationTime = file.lastModified(); 
+        long creationTime = file.lastModified();
         long modificationTime = file.lastModified();
         boolean dirFlag = file.isDirectory();
         long fileSize = file.length();
-        
-        Object[] array = { fHandler.makeStString( name ),
-                fHandler.squeakSeconds( creationTime ),
-                fHandler.squeakSeconds( modificationTime ),
-                fHandler.squeakBool( dirFlag ),
-                fHandler.pos32BitIntFor( fileSize ) };
-        
-        return fHandler.squeakArray( array );
+
+        Object[] array = {fHandler.makeStString(name),
+                fHandler.squeakSeconds(creationTime),
+                fHandler.squeakSeconds(modificationTime),
+                fHandler.squeakBool(dirFlag),
+                fHandler.pos32BitIntFor(fileSize)};
+
+        return fHandler.squeakArray(array);
     }
 
     // -- Support methods -----------------------------------------------------------------
 
-    
-    private void setFile( SqueakObject fileId, RandomAccessFile file )
-    {
-        fFiles.put( fileId, file );
+
+    private void setFile(SqueakObject fileId, RandomAccessFile file) {
+        fFiles.put(fileId, file);
     }
 
     /**
      * @return the file associated with the file ID at depth 0 of the argument
      */
-    private RandomAccessFile lookupFile()
-    {
-        return lookupFile( 0 );
+    private RandomAccessFile lookupFile() {
+        return lookupFile(0);
     }
-    
+
     /**
      * @return the file associated with the file ID in the given stack position
      */
-    private RandomAccessFile lookupFile( int stackDepth )
-    {
-        SqueakObject fileId = fHandler.stackNonInteger( stackDepth );
-        if ( ! fFiles.containsKey( fileId ) )
-            throw fHandler.primitiveFailed(); 
-            
-        return (RandomAccessFile) fFiles.get( fileId );
+    private RandomAccessFile lookupFile(int stackDepth) {
+        SqueakObject fileId = fHandler.stackNonInteger(stackDepth);
+        if (!fFiles.containsKey(fileId))
+            throw fHandler.primitiveFailed();
+
+        return (RandomAccessFile) fFiles.get(fileId);
     }
 }

--- a/src/JSqueak/Main.java
+++ b/src/JSqueak/Main.java
@@ -31,21 +31,15 @@ THE SOFTWARE.
 
 package JSqueak;
 
-public class Main 
-{
-    public Main() 
-    {
+public class Main {
+    public Main() {
         // nothing to do
     }
-    
-    public static void main(String[] args) 
-    {
-        try 
-        {
+
+    public static void main(String[] args) {
+        try {
             Starter.main(new String[0]);
-        }
-        catch (Exception ex ) 
-        {
+        } catch (Exception ex) {
             ex.printStackTrace();
         }
     }

--- a/src/JSqueak/Screen.java
+++ b/src/JSqueak/Screen.java
@@ -69,8 +69,7 @@ import JSqueak.input.InputNotifyThread;
 import JSqueak.input.KeyboardQueue;
 import JSqueak.input.MouseStatus;
 
-public class Screen 
-{
+public class Screen {
     Dimension fExtent;
     private int fDepth;
     private JFrame fFrame;
@@ -79,289 +78,244 @@ public class Screen
     private MouseStatus fMouseStatus;
     private KeyboardQueue fKeyboardQueue;
     private InputNotifyThread inputNotifyThread;
-    
+
     private Timer fHeartBeat;
     private boolean fScreenChanged;
     private Object fVMSemaphore;
-    
-    private final static boolean WITH_HEARTBEAT= false;
-    private final static int FPS= 10;
-    
+
+    private final static boolean WITH_HEARTBEAT = false;
+    private final static int FPS = 10;
+
     // cf. http://doc.novsu.ac.ru/oreilly/java/awt/ch12_02.htm
     private final static byte kComponents[] =
-        new byte[]{ (byte)255, 0 , (byte)240, (byte)230, 
-                    (byte)220, (byte)210, (byte)200, (byte)190, (byte)180, (byte)170,
-                    (byte)160, (byte)150, 110, 70, 30, 10 };
-    
+            new byte[]{(byte) 255, 0, (byte) 240, (byte) 230,
+                    (byte) 220, (byte) 210, (byte) 200, (byte) 190, (byte) 180, (byte) 170,
+                    (byte) 160, (byte) 150, 110, 70, 30, 10};
+
     private final static ColorModel kBlackAndWhiteModel =
-        new IndexColorModel(1, 2, kComponents, kComponents, kComponents);
-    
-    public Screen(String title, int width, int height, int depth, Object vmSema) 
-    {
-        fVMSemaphore= vmSema;
-        fExtent= new Dimension(width, height);
-        fDepth= depth;
-        fFrame= new JFrame(title);
+            new IndexColorModel(1, 2, kComponents, kComponents, kComponents);
+
+    public Screen(String title, int width, int height, int depth, Object vmSema) {
+        fVMSemaphore = vmSema;
+        fExtent = new Dimension(width, height);
+        fDepth = depth;
+        fFrame = new JFrame(title);
         fFrame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-        JPanel content= new JPanel(new BorderLayout());
-        Icon noDisplay= new Icon() 
-        {
-            public int getIconWidth() 
-            {
-                return fExtent.width; 
+        JPanel content = new JPanel(new BorderLayout());
+        Icon noDisplay = new Icon() {
+            public int getIconWidth() {
+                return fExtent.width;
             }
-            
-            public int getIconHeight() 
-            {
-                return fExtent.height; 
+
+            public int getIconHeight() {
+                return fExtent.height;
             }
-            
-            public void paintIcon(Component c, Graphics g, int x, int y) {}
+
+            public void paintIcon(Component c, Graphics g, int x, int y) {
+            }
         };
-        fDisplay= new JLabel(noDisplay);
+        fDisplay = new JLabel(noDisplay);
         fDisplay.setSize(fExtent);
         content.add(fDisplay, BorderLayout.CENTER);
         fFrame.setContentPane(content);
         Dimension screen = Toolkit.getDefaultToolkit().getScreenSize();
-        fFrame.setLocation((screen.width - fExtent.width)/2, (screen.height - fExtent.height)/2);   // center
-        
-        fMouseStatus= new MouseStatus( (SqueakVM) fVMSemaphore );
-        fDisplay.addMouseMotionListener( fMouseStatus );
+        fFrame.setLocation((screen.width - fExtent.width) / 2, (screen.height - fExtent.height) / 2);   // center
+
+        fMouseStatus = new MouseStatus((SqueakVM) fVMSemaphore);
+        fDisplay.addMouseMotionListener(fMouseStatus);
         fDisplay.addMouseListener(fMouseStatus);
-        
+
         fDisplay.setFocusable(true);    // enable keyboard input
-        fKeyboardQueue= new KeyboardQueue( (SqueakVM) fVMSemaphore );
-        fDisplay.addKeyListener( fKeyboardQueue );
-        
+        fKeyboardQueue = new KeyboardQueue((SqueakVM) fVMSemaphore);
+        fDisplay.addKeyListener(fKeyboardQueue);
+
         inputNotifyThread = new InputNotifyThread((SqueakVM) fVMSemaphore);
         inputNotifyThread.start();
-        
+
         fDisplay.setOpaque(true);
         fDisplay.getRootPane().setDoubleBuffered(false);    // prevents losing intermediate redraws (how?!)
     }
-    
-    public JFrame getFrame() 
-    {
-        return fFrame; 
+
+    public JFrame getFrame() {
+        return fFrame;
     }
-    
-    public void setBits(byte rawBits[], int depth) 
-    {
-        fDepth= depth;
-        fDisplay.setIcon(createDisplayAdapter(fDisplayBits= rawBits)); 
+
+    public void setBits(byte rawBits[], int depth) {
+        fDepth = depth;
+        fDisplay.setIcon(createDisplayAdapter(fDisplayBits = rawBits));
     }
-    
-    byte[] getBits() 
-    {
-        return fDisplayBits; 
+
+    byte[] getBits() {
+        return fDisplayBits;
     }
-    
-    protected Icon createDisplayAdapter(byte storage[]) 
-    {
-        DataBuffer buf= new DataBufferByte(storage, (fExtent.height*fExtent.width/8)*fDepth);       // single bank
-        SampleModel sm= new MultiPixelPackedSampleModel(DataBuffer.TYPE_BYTE, fExtent.width, fExtent.height, fDepth /* bpp */);
-        WritableRaster raster= Raster.createWritableRaster(sm, buf, new Point(0, 0));
-        Image image= new BufferedImage(kBlackAndWhiteModel, raster, true, null);
-        return new ImageIcon(image); 
+
+    protected Icon createDisplayAdapter(byte storage[]) {
+        DataBuffer buf = new DataBufferByte(storage, (fExtent.height * fExtent.width / 8) * fDepth);       // single bank
+        SampleModel sm = new MultiPixelPackedSampleModel(DataBuffer.TYPE_BYTE, fExtent.width, fExtent.height, fDepth /* bpp */);
+        WritableRaster raster = Raster.createWritableRaster(sm, buf, new Point(0, 0));
+        Image image = new BufferedImage(kBlackAndWhiteModel, raster, true, null);
+        return new ImageIcon(image);
     }
-    
-    public void open() 
-    {
+
+    public void open() {
         fFrame.pack();
         fFrame.setVisible(true);
-        if (WITH_HEARTBEAT) 
-        {
-            fHeartBeat= new Timer(1000/FPS /* ms */, new ActionListener() 
-            {
-                public void actionPerformed(ActionEvent evt) 
-                {
+        if (WITH_HEARTBEAT) {
+            fHeartBeat = new Timer(1000 / FPS /* ms */, new ActionListener() {
+                public void actionPerformed(ActionEvent evt) {
                     // Swing timers execute on EHT
-                    if (fScreenChanged) 
-                    {
+                    if (fScreenChanged) {
                         // could use synchronization, but lets rather paint too often
-                        fScreenChanged= false;
-                        Dimension extent= fDisplay.getSize();
+                        fScreenChanged = false;
+                        Dimension extent = fDisplay.getSize();
                         fDisplay.paintImmediately(0, 0, extent.width, extent.height);
                         // Toolkit.getDefaultToolkit().beep();      // FIXME remove
                     }
                 }
-            } );
-            fHeartBeat.start(); 
+            });
+            fHeartBeat.start();
         }
     }
-    
-    public void close() 
-    {
+
+    public void close() {
         fFrame.setVisible(false);
         fFrame.dispose();
         if (WITH_HEARTBEAT)
-            fHeartBeat.stop(); 
+            fHeartBeat.stop();
     }
-    
-    public void redisplay(boolean immediately, Rectangle area) 
-    {
-        redisplay(immediately, area.x, area.y, area.width, area.height); 
+
+    public void redisplay(boolean immediately, Rectangle area) {
+        redisplay(immediately, area.x, area.y, area.width, area.height);
     }
-    
-    public void redisplay(boolean immediately, final int cornerX, final int cornerY, final int width, final int height) 
-    {
+
+    public void redisplay(boolean immediately, final int cornerX, final int cornerY, final int width, final int height) {
         fDisplay.repaint(cornerX, cornerY, width, height);
-        fScreenChanged= true; 
+        fScreenChanged = true;
     }
-    
-    public void redisplay(boolean immediately) 
-    {
+
+    public void redisplay(boolean immediately) {
         fDisplay.repaint();
-        fScreenChanged= true; 
+        fScreenChanged = true;
     }
-    
-    protected boolean scheduleRedisplay(boolean immediately, Runnable trigger) 
-    {
-        if (immediately) 
-        {
-            try
-            {
+
+    protected boolean scheduleRedisplay(boolean immediately, Runnable trigger) {
+        if (immediately) {
+            try {
                 SwingUtilities.invokeAndWait(trigger);
-                return true; 
-            }
-            catch (InterruptedException e) 
-            {
-                logRedisplayException(e); 
-            }
-            catch (InvocationTargetException e) 
-            {
+                return true;
+            } catch (InterruptedException e) {
+                logRedisplayException(e);
+            } catch (InvocationTargetException e) {
                 logRedisplayException(e);
             }
-            return false; 
-        }
-        else 
-        {
+            return false;
+        } else {
             SwingUtilities.invokeLater(trigger);
-            return true; 
+            return true;
         }
     }
-    
+
     // extension point, default is ignorance
-    protected void logRedisplayException(Exception e) {}
-    
-    private final static int Squeak_CURSOR_WIDTH= 16;
-    private final static int Squeak_CURSOR_HEIGHT= 16;
-    
-    private final static byte C_WHITE= 0;
-    private final static byte C_BLACK= 1;
-    private final static byte C_TRANSPARENT= 2;
-    private final static byte kCursorComponentX[]= new byte[] { -1, 0, 0 };
-    private final static byte kCursorComponentA[]= new byte[] { -1, -1, 0 };
-    
-    protected Image createCursorAdapter(byte bits[], byte mask[]) 
-    {
-        int bufSize= Squeak_CURSOR_HEIGHT*Squeak_CURSOR_WIDTH;
-        DataBuffer buf= new DataBufferByte(new byte[bufSize], bufSize);
+    protected void logRedisplayException(Exception e) {
+    }
+
+    private final static int Squeak_CURSOR_WIDTH = 16;
+    private final static int Squeak_CURSOR_HEIGHT = 16;
+
+    private final static byte C_WHITE = 0;
+    private final static byte C_BLACK = 1;
+    private final static byte C_TRANSPARENT = 2;
+    private final static byte kCursorComponentX[] = new byte[]{-1, 0, 0};
+    private final static byte kCursorComponentA[] = new byte[]{-1, -1, 0};
+
+    protected Image createCursorAdapter(byte bits[], byte mask[]) {
+        int bufSize = Squeak_CURSOR_HEIGHT * Squeak_CURSOR_WIDTH;
+        DataBuffer buf = new DataBufferByte(new byte[bufSize], bufSize);
         // unpack samples and mask to bytes with transparency:
-        int p= 0;
-        for (int row= 0; row<Squeak_CURSOR_HEIGHT; row++) 
-        {
-            for (int x=0; x<2; x++) 
-            {
-                for (int col= 0x80; col!=0; col>>>= 1) 
-                {
-                    if ((mask[(row*4)+x] & col) != 0)
-                        buf.setElem(p++, (bits[(row*4)+x] & col) != 0? C_BLACK : C_WHITE);
+        int p = 0;
+        for (int row = 0; row < Squeak_CURSOR_HEIGHT; row++) {
+            for (int x = 0; x < 2; x++) {
+                for (int col = 0x80; col != 0; col >>>= 1) {
+                    if ((mask[(row * 4) + x] & col) != 0)
+                        buf.setElem(p++, (bits[(row * 4) + x] & col) != 0 ? C_BLACK : C_WHITE);
                     else
-                        buf.setElem(p++, C_TRANSPARENT); 
+                        buf.setElem(p++, C_TRANSPARENT);
                 }
             }
         }
-        SampleModel sm= new SinglePixelPackedSampleModel(DataBuffer.TYPE_BYTE, Squeak_CURSOR_WIDTH, Squeak_CURSOR_HEIGHT, new int[]{ 255 });
-        IndexColorModel cm= new IndexColorModel(8, 3, kCursorComponentX, kCursorComponentX, kCursorComponentX, kCursorComponentA);
-        WritableRaster raster= Raster.createWritableRaster(sm, buf, new Point(0, 0));
-        return new BufferedImage(cm, raster, false, null); 
+        SampleModel sm = new SinglePixelPackedSampleModel(DataBuffer.TYPE_BYTE, Squeak_CURSOR_WIDTH, Squeak_CURSOR_HEIGHT, new int[]{255});
+        IndexColorModel cm = new IndexColorModel(8, 3, kCursorComponentX, kCursorComponentX, kCursorComponentX, kCursorComponentA);
+        WritableRaster raster = Raster.createWritableRaster(sm, buf, new Point(0, 0));
+        return new BufferedImage(cm, raster, false, null);
     }
-    
-    protected byte[] extractBits(byte bitsAndMask[], int offset) 
-    {
-        final int n= bitsAndMask.length/2;  // 32 bytes -> 8 bytes
-        byte answer[]= new byte[n];
-        for (int i= 0; i<n; i++) 
-        {
+
+    protected byte[] extractBits(byte bitsAndMask[], int offset) {
+        final int n = bitsAndMask.length / 2;  // 32 bytes -> 8 bytes
+        byte answer[] = new byte[n];
+        for (int i = 0; i < n; i++) {
             // convert incoming little-endian words to bytes:
-            answer[i]= bitsAndMask[offset + i]; 
+            answer[i] = bitsAndMask[offset + i];
         }
-        return answer; 
+        return answer;
     }
-    
-    public void setCursor(byte imageAndMask[], int BWMask) 
-    {
-        int n= imageAndMask.length;
-        for(int i=0; i<n/2; i++) 
-        {
+
+    public void setCursor(byte imageAndMask[], int BWMask) {
+        int n = imageAndMask.length;
+        for (int i = 0; i < n / 2; i++) {
             imageAndMask[i] ^= BWMask; // reverse cursor bits all the time
-            imageAndMask[i+(n/2)] ^= BWMask;  // reverse transparency if display reversed
+            imageAndMask[i + (n / 2)] ^= BWMask;  // reverse transparency if display reversed
         }
-        Toolkit tk= Toolkit.getDefaultToolkit();
-        Dimension cx= tk.getBestCursorSize(Squeak_CURSOR_WIDTH, Squeak_CURSOR_HEIGHT);
+        Toolkit tk = Toolkit.getDefaultToolkit();
+        Dimension cx = tk.getBestCursorSize(Squeak_CURSOR_WIDTH, Squeak_CURSOR_HEIGHT);
         Cursor c;
-        if (cx.width == 0 || cx.height == 0) 
-        {
-            c= Cursor.getDefaultCursor(); 
+        if (cx.width == 0 || cx.height == 0) {
+            c = Cursor.getDefaultCursor();
+        } else {
+            Image ci = createCursorAdapter(extractBits(imageAndMask, 0), extractBits(imageAndMask, Squeak_CURSOR_HEIGHT * 4));
+            c = tk.createCustomCursor(ci, new Point(0, 0), "Smalltalk-78 cursor");
         }
-        else 
-        {
-            Image ci= createCursorAdapter(extractBits(imageAndMask, 0), extractBits(imageAndMask, Squeak_CURSOR_HEIGHT*4));
-            c= tk.createCustomCursor(ci, new Point(0, 0), "Smalltalk-78 cursor"); 
-        }
-        fDisplay.setCursor(c); 
+        fDisplay.setCursor(c);
     }
-    
-    public Dimension getExtent() 
-    {
-        return fDisplay.getSize(); 
+
+    public Dimension getExtent() {
+        return fDisplay.getSize();
     }
-    
-    public void setExtent(Dimension extent) 
-    {
+
+    public void setExtent(Dimension extent) {
         fDisplay.setSize(extent);
-        fFrame.setSize(extent); 
+        fFrame.setSize(extent);
     }
-    
-    public Point getLastMousePoint() 
-    {
-        return new Point(fMouseStatus.fX, fMouseStatus.fY); 
+
+    public Point getLastMousePoint() {
+        return new Point(fMouseStatus.fX, fMouseStatus.fY);
     }
-    
-    public int getLastMouseButtonStatus() 
-    {
-        return ( fMouseStatus.fButtons & 7 ) | fKeyboardQueue.modifierKeys();
+
+    public int getLastMouseButtonStatus() {
+        return (fMouseStatus.fButtons & 7) | fKeyboardQueue.modifierKeys();
     }
-    
-    public void setMousePoint(int x, int y) 
-    {
-        Point origin= fDisplay.getLocationOnScreen();
-        x+= origin.x;
-        y+= origin.y;
-        try 
-        {
+
+    public void setMousePoint(int x, int y) {
+        Point origin = fDisplay.getLocationOnScreen();
+        x += origin.x;
+        y += origin.y;
+        try {
             Robot robot = new Robot();
-            robot.mouseMove(x, y); 
-        }
-        catch (AWTException e) 
-        {
+            robot.mouseMove(x, y);
+        } catch (AWTException e) {
             // ignore silently?
-            System.err.println("Mouse move to " + x + "@" + y + " failed."); 
+            System.err.println("Mouse move to " + x + "@" + y + " failed.");
         }
     }
-    
-    public int keyboardPeek() 
-    {
-        return fKeyboardQueue.peek(); 
+
+    public int keyboardPeek() {
+        return fKeyboardQueue.peek();
     }
-    
-    public int keyboardNext() 
-    {
+
+    public int keyboardNext() {
         //System.err.println("character code="+fKeyboardQueue.peek());
-        return fKeyboardQueue.next(); 
+        return fKeyboardQueue.next();
     }
-    
+
     public void exit() {
         inputNotifyThread.quit();
         fFrame.setVisible(false);

--- a/src/JSqueak/Squeak.java
+++ b/src/JSqueak/Squeak.java
@@ -25,158 +25,156 @@ package JSqueak;
 
 /**
  * @author Dan Ingalls
- *
  */
-public interface Squeak 
-{
-    
+public interface Squeak {
+
     // Squeak Headers
-    public final static int HeaderTypeMask= 3;
-    public final static int HeaderTypeSizeAndClass= 0; //3-word header
-    public final static int HeaderTypeClass= 1;        //2-word header
-    public final static int HeaderTypeFree= 2;         //free block
-    public final static int HeaderTypeShort= 3;        //1-word header
-    
+    public final static int HeaderTypeMask = 3;
+    public final static int HeaderTypeSizeAndClass = 0; //3-word header
+    public final static int HeaderTypeClass = 1;        //2-word header
+    public final static int HeaderTypeFree = 2;         //free block
+    public final static int HeaderTypeShort = 3;        //1-word header
+
     //Indices into SpecialObjects array
-    public final static int splOb_NilObject= 0;
-    public final static int splOb_FalseObject= 1;
-    public final static int splOb_TrueObject= 2;
-    public final static int splOb_SchedulerAssociation= 3;
-    public final static int splOb_ClassBitmap= 4;
-    public final static int splOb_ClassInteger= 5;
-    public final static int splOb_ClassString= 6;
-    public final static int splOb_ClassArray= 7;
+    public final static int splOb_NilObject = 0;
+    public final static int splOb_FalseObject = 1;
+    public final static int splOb_TrueObject = 2;
+    public final static int splOb_SchedulerAssociation = 3;
+    public final static int splOb_ClassBitmap = 4;
+    public final static int splOb_ClassInteger = 5;
+    public final static int splOb_ClassString = 6;
+    public final static int splOb_ClassArray = 7;
     //public final static int splOb_SmalltalkDictionary= 8;  old slot 8
-    public final static int splOb_ClassFloat= 9;
-    public final static int splOb_ClassMethodContext= 10;
-    public final static int splOb_ClassBlockContext= 11;
-    public final static int splOb_ClassPoint= 12;
-    public final static int splOb_ClassLargePositiveInteger= 13;
-    public final static int splOb_TheDisplay= 14;
-    public final static int splOb_ClassMessage= 15;
-    public final static int splOb_ClassCompiledMethod= 16;
-    public final static int splOb_TheLowSpaceSemaphore= 17;
-    public final static int splOb_ClassSemaphore= 18;
-    public final static int splOb_ClassCharacter= 19;
-    public final static int splOb_SelectorDoesNotUnderstand= 20;
-    public final static int splOb_SelectorCannotReturn= 21;
-    public final static int splOb_TheInputSemaphore= 22;
-    public final static int splOb_SpecialSelectors= 23;
-    public final static int splOb_CharacterTable= 24;
-    public final static int splOb_SelectorMustBeBoolean= 25;
-    public final static int splOb_ClassByteArray= 26;
-    public final static int splOb_ClassProcess= 27;
-    public final static int splOb_CompactClasses= 28;
-    public final static int splOb_TheTimerSemaphore= 29;
-    public final static int splOb_TheInterruptSemaphore= 30;
-    public final static int splOb_FloatProto= 31;
-    public final static int splOb_SelectorCannotInterpret= 34;
-    public final static int splOb_MethodContextProto= 35;
-    public final static int splOb_BlockContextProto= 37;
-    public final static int splOb_ExternalObjectsArray= 38;
-    public final static int splOb_ClassPseudoContext= 39;
-    public final static int splOb_ClassTranslatedMethod= 40;
-    public final static int splOb_TheFinalizationSemaphore= 41;
-    public final static int splOb_ClassLargeNegativeInteger= 42;
-    public final static int splOb_ClassExternalAddress= 43;
-    public final static int splOb_ClassExternalStructure= 44;
-    public final static int splOb_ClassExternalData= 45;
-    public final static int splOb_ClassExternalFunction= 46;
-    public final static int splOb_ClassExternalLibrary= 47;
-    public final static int splOb_SelectorAboutToReturn= 48;
-    
-    
+    public final static int splOb_ClassFloat = 9;
+    public final static int splOb_ClassMethodContext = 10;
+    public final static int splOb_ClassBlockContext = 11;
+    public final static int splOb_ClassPoint = 12;
+    public final static int splOb_ClassLargePositiveInteger = 13;
+    public final static int splOb_TheDisplay = 14;
+    public final static int splOb_ClassMessage = 15;
+    public final static int splOb_ClassCompiledMethod = 16;
+    public final static int splOb_TheLowSpaceSemaphore = 17;
+    public final static int splOb_ClassSemaphore = 18;
+    public final static int splOb_ClassCharacter = 19;
+    public final static int splOb_SelectorDoesNotUnderstand = 20;
+    public final static int splOb_SelectorCannotReturn = 21;
+    public final static int splOb_TheInputSemaphore = 22;
+    public final static int splOb_SpecialSelectors = 23;
+    public final static int splOb_CharacterTable = 24;
+    public final static int splOb_SelectorMustBeBoolean = 25;
+    public final static int splOb_ClassByteArray = 26;
+    public final static int splOb_ClassProcess = 27;
+    public final static int splOb_CompactClasses = 28;
+    public final static int splOb_TheTimerSemaphore = 29;
+    public final static int splOb_TheInterruptSemaphore = 30;
+    public final static int splOb_FloatProto = 31;
+    public final static int splOb_SelectorCannotInterpret = 34;
+    public final static int splOb_MethodContextProto = 35;
+    public final static int splOb_BlockContextProto = 37;
+    public final static int splOb_ExternalObjectsArray = 38;
+    public final static int splOb_ClassPseudoContext = 39;
+    public final static int splOb_ClassTranslatedMethod = 40;
+    public final static int splOb_TheFinalizationSemaphore = 41;
+    public final static int splOb_ClassLargeNegativeInteger = 42;
+    public final static int splOb_ClassExternalAddress = 43;
+    public final static int splOb_ClassExternalStructure = 44;
+    public final static int splOb_ClassExternalData = 45;
+    public final static int splOb_ClassExternalFunction = 46;
+    public final static int splOb_ClassExternalLibrary = 47;
+    public final static int splOb_SelectorAboutToReturn = 48;
+
+
     // Class layout:
-    public final static int Class_superclass= 0;
-    public final static int Class_mdict= 1;
-    public final static int Class_format= 2;
-    public final static int Class_name= 6;
-    
+    public final static int Class_superclass = 0;
+    public final static int Class_mdict = 1;
+    public final static int Class_format = 2;
+    public final static int Class_name = 6;
+
     // Context layout
-    public final static int Context_sender= 0;
-    public final static int Context_instructionPointer= 1;
-    public final static int Context_stackPointer= 2;
-    public final static int Context_method= 3;
-    public final static int Context_receiver= 5;
-    public final static int Context_tempFrameStart= 6;
-    public final static int Context_smallFrameSize= 17;
-    public final static int Context_largeFrameSize= 57;
-    public final static int BlockContext_caller= 0;
-    public final static int BlockContext_argumentCount= 3;
-    public final static int BlockContext_initialIP= 4;
-    public final static int BlockContext_home= 5;
+    public final static int Context_sender = 0;
+    public final static int Context_instructionPointer = 1;
+    public final static int Context_stackPointer = 2;
+    public final static int Context_method = 3;
+    public final static int Context_receiver = 5;
+    public final static int Context_tempFrameStart = 6;
+    public final static int Context_smallFrameSize = 17;
+    public final static int Context_largeFrameSize = 57;
+    public final static int BlockContext_caller = 0;
+    public final static int BlockContext_argumentCount = 3;
+    public final static int BlockContext_initialIP = 4;
+    public final static int BlockContext_home = 5;
 
     // Stream layout:
-    public final static int Stream_array= 0;
-    public final static int Stream_position= 1;
-    public final static int Stream_limit= 2;
+    public final static int Stream_array = 0;
+    public final static int Stream_position = 1;
+    public final static int Stream_limit = 2;
 
     //Class ProcessorScheduler"
-    public final static int ProcSched_processLists= 0;
-    public final static int ProcSched_activeProcess= 1;
+    public final static int ProcSched_processLists = 0;
+    public final static int ProcSched_activeProcess = 1;
 
     //Class Link"
-    public final static int Link_nextLink= 0;
+    public final static int Link_nextLink = 0;
 
     //Class LinkedList"
-    public final static int LinkedList_firstLink= 0;
-    public final static int LinkedList_lastLink= 1;
+    public final static int LinkedList_firstLink = 0;
+    public final static int LinkedList_lastLink = 1;
 
     //Class Semaphore"
-    public final static int Semaphore_excessSignals= 2;
+    public final static int Semaphore_excessSignals = 2;
 
     //Class Process"
-    public final static int Proc_suspendedContext= 1;
-    public final static int Proc_priority= 2;
-    public final static int Proc_myList= 3; 
+    public final static int Proc_suspendedContext = 1;
+    public final static int Proc_priority = 2;
+    public final static int Proc_myList = 3;
 
     // Association layout:
-    public final static int Assn_key= 0;
-    public final static int Assn_value= 1;
+    public final static int Assn_key = 0;
+    public final static int Assn_value = 1;
 
     // MethodDict layout:
-    public final static int MethodDict_array= 1;
-    public final static int MethodDict_selectorStart= 2;
+    public final static int MethodDict_array = 1;
+    public final static int MethodDict_selectorStart = 2;
 
     // Message layout
-    public final static int Message_selector= 0;
-    public final static int Message_arguments= 1;
-    public final static int Message_lookupClass= 2;
+    public final static int Message_selector = 0;
+    public final static int Message_arguments = 1;
+    public final static int Message_lookupClass = 2;
 
     // Point layout:
-    public final static int Point_x= 0;
-    public final static int Point_y= 1;
+    public final static int Point_x = 0;
+    public final static int Point_y = 1;
 
     // Largetinteger layout:
-    public final static int Largeinteger_bytes= 0;
-    public final static int Largeinteger_neg= 1;
+    public final static int Largeinteger_bytes = 0;
+    public final static int Largeinteger_neg = 1;
 
     // Bitblt layout:
-    public final static int Bitblt_function= 0;
-    public final static int Bitblt_gray= 1;
-    public final static int Bitblt_destbits= 2;
-    public final static int Bitblt_destraster= 3;
-    public final static int Bitblt_destx= 4;
-    public final static int Bitblt_desty= 5;
-    public final static int Bitblt_width= 6;
-    public final static int Bitblt_height= 7;
-    public final static int Bitblt_sourcebits= 8;
-    public final static int Bitblt_sourceraster= 9;
-    public final static int Bitblt_sourcex= 10;
-    public final static int Bitblt_sourcey= 11;
-    public final static int Bitblt_clipx= 12;
-    public final static int Bitblt_clipy= 13;
-    public final static int Bitblt_clipwidth= 14;
-    public final static int Bitblt_clipheight= 15;
-    public final static int Bitblt_sourcefield= 16;
-    public final static int Bitblt_destfield= 17;
-    public final static int Bitblt_source= 18;
-    public final static int Bitblt_dest= 19;
+    public final static int Bitblt_function = 0;
+    public final static int Bitblt_gray = 1;
+    public final static int Bitblt_destbits = 2;
+    public final static int Bitblt_destraster = 3;
+    public final static int Bitblt_destx = 4;
+    public final static int Bitblt_desty = 5;
+    public final static int Bitblt_width = 6;
+    public final static int Bitblt_height = 7;
+    public final static int Bitblt_sourcebits = 8;
+    public final static int Bitblt_sourceraster = 9;
+    public final static int Bitblt_sourcex = 10;
+    public final static int Bitblt_sourcey = 11;
+    public final static int Bitblt_clipx = 12;
+    public final static int Bitblt_clipy = 13;
+    public final static int Bitblt_clipwidth = 14;
+    public final static int Bitblt_clipheight = 15;
+    public final static int Bitblt_sourcefield = 16;
+    public final static int Bitblt_destfield = 17;
+    public final static int Bitblt_source = 18;
+    public final static int Bitblt_dest = 19;
 
     // Form layout:
-    public final static int Form_bits= 0;
-    public final static int Form_width= 1;
-    public final static int Form_height= 2;
-    public final static int Form_depth= 3;
+    public final static int Form_bits = 0;
+    public final static int Form_width = 1;
+    public final static int Form_height = 2;
+    public final static int Form_depth = 3;
 
 }

--- a/src/JSqueak/SqueakConfig.java
+++ b/src/JSqueak/SqueakConfig.java
@@ -1,0 +1,10 @@
+package JSqueak;
+
+/**
+ * Global config for JSqueak
+ */
+public class SqueakConfig {
+
+    public static final boolean DEBUG_LOGGING = true;
+
+}

--- a/src/JSqueak/SqueakImage.java
+++ b/src/JSqueak/SqueakImage.java
@@ -41,390 +41,347 @@ import java.util.zip.GZIPOutputStream;
 
 /**
  * @author Daniel Ingalls
- *
+ * <p>
  * A SqueakImage represents the complete state of a running Squeak.
  * This implemenatation uses Java objects (see SqueakObject) for all Squeak objects,
  * with direct pointers between them.  Enumeration is supported by objectTable,
  * which points weakly to all objects.  SmallIntegers are modelled by Java Integers.
- *
+ * <p>
  * Some care is taken in reclaiming OT slots, to preserve the order of creation of objects,
  * as this matters for Squeak weak objects, should we ever support them.
  */
 
-public class SqueakImage 
-{
+public class SqueakImage {
     private final String DEFAULT_IMAGE_NAME = "jsqueak.image";
-    
+
     private SqueakVM vm;
     private WeakReference[] objectTable;
     private int otMaxUsed;
     private int otMaxOld;
     private int lastHash;
     private int lastOTindex;
-    
+
     private File imageFile;
-    
+
     // FIXME: Access this through a method
     SqueakObject specialObjectsArray;
-    
-    public SqueakImage(InputStream raw) throws IOException 
-    {
-        imageFile = new File( System.getProperty( "user.dir" ),
-                              DEFAULT_IMAGE_NAME );
-        loaded(raw); 
+
+    public SqueakImage(InputStream raw) throws IOException {
+        imageFile = new File(System.getProperty("user.dir"),
+                DEFAULT_IMAGE_NAME);
+        loaded(raw);
     }
-    
-    public SqueakImage( File fn ) throws IOException 
-    {
+
+    public SqueakImage(File fn) throws IOException {
         imageFile = fn;
-        loaded(fn); 
+        loaded(fn);
     }
-    
-    public void save(File fn) throws IOException 
-    {
-        BufferedOutputStream fp= new BufferedOutputStream(new FileOutputStream(fn));
-        GZIPOutputStream gz= new GZIPOutputStream(fp);
-        DataOutputStream ser= new DataOutputStream(gz);
+
+    public void save(File fn) throws IOException {
+        BufferedOutputStream fp = new BufferedOutputStream(new FileOutputStream(fn));
+        GZIPOutputStream gz = new GZIPOutputStream(fp);
+        DataOutputStream ser = new DataOutputStream(gz);
         writeImage(ser);
         ser.flush();
         ser.close();
         imageFile = fn;
     }
 
-    File imageFile()
-    {
+    File imageFile() {
         return imageFile;
     }
-    
-    void bindVM(SqueakVM theVM) 
-    {
-        vm = theVM; 
-    }
-    
-    private void loaded(InputStream raw) throws IOException 
-    {
-        BufferedInputStream fp= new BufferedInputStream(raw);
-        GZIPInputStream gz= new GZIPInputStream(fp);
-        DataInputStream ser= new DataInputStream(gz);
-        readImage(ser); 
+
+    void bindVM(SqueakVM theVM) {
+        vm = theVM;
     }
 
-    private void loaded(File fn) throws IOException 
-    {
-        FileInputStream unbuffered= new FileInputStream(fn);
-        loaded(unbuffered);
-        unbuffered.close(); 
+    private void loaded(InputStream raw) throws IOException {
+        BufferedInputStream fp = new BufferedInputStream(raw);
+        GZIPInputStream gz = new GZIPInputStream(fp);
+        DataInputStream ser = new DataInputStream(gz);
+        readImage(ser);
     }
-    
-    boolean bulkBecome(Object[] fromPointers, Object[] toPointers, boolean twoWay) 
-    {
-        int n= fromPointers.length;
+
+    private void loaded(File fn) throws IOException {
+        FileInputStream unbuffered = new FileInputStream(fn);
+        loaded(unbuffered);
+        unbuffered.close();
+    }
+
+    boolean bulkBecome(Object[] fromPointers, Object[] toPointers, boolean twoWay) {
+        int n = fromPointers.length;
         Object p, ptr, body[], mut;
         SqueakObject obj;
-        if (n != toPointers.length) 
+        if (n != toPointers.length)
             return false;
-        Hashtable mutations= new Hashtable(n*4*(twoWay?2:1));
-        for(int i=0; i<n; i++) 
-        {
-            p= fromPointers[i];
-            if (!(p instanceof SqueakObject)) 
+        Hashtable mutations = new Hashtable(n * 4 * (twoWay ? 2 : 1));
+        for (int i = 0; i < n; i++) {
+            p = fromPointers[i];
+            if (!(p instanceof SqueakObject))
                 return false;  //non-objects in from array
-            if (mutations.get(p) != null) 
+            if (mutations.get(p) != null)
                 return false; //repeated oops in from array
-            else 
-                mutations.put(p,toPointers[i]); 
+            else
+                mutations.put(p, toPointers[i]);
         }
-        if (twoWay) 
-        {
-            for(int i=0; i<n; i++) 
-            {
-                p= toPointers[i];
-                if (!(p instanceof SqueakObject)) 
+        if (twoWay) {
+            for (int i = 0; i < n; i++) {
+                p = toPointers[i];
+                if (!(p instanceof SqueakObject))
                     return false;  //non-objects in to array
-                if (mutations.get(p) != null) 
+                if (mutations.get(p) != null)
                     return false; //repeated oops in to array
-                else 
-                    mutations.put(p,fromPointers[i]); 
+                else
+                    mutations.put(p, fromPointers[i]);
             }
         }
-        for(int i=0; i<=otMaxUsed; i++) 
-        {
+        for (int i = 0; i <= otMaxUsed; i++) {
             // Now, for every object...
-            obj= (SqueakObject)objectTable[i].get();
-            if (obj != null) 
-            {
+            obj = (SqueakObject) objectTable[i].get();
+            if (obj != null) {
                 // mutate the class
-                mut = (SqueakObject)mutations.get(obj.sqClass);
+                mut = (SqueakObject) mutations.get(obj.sqClass);
                 if (mut != null)
-                    obj.sqClass= mut; 
-                if ((body= obj.pointers) != null)
-                {
+                    obj.sqClass = mut;
+                if ((body = obj.pointers) != null) {
                     // and mutate body pointers
-                    for(int j=0; j<body.length; j++) 
-                    {
-                        ptr= body[j];
-                        mut= mutations.get(ptr);
-                        if (mut != null) 
-                            body[j]= mut; 
+                    for (int j = 0; j < body.length; j++) {
+                        ptr = body[j];
+                        mut = mutations.get(ptr);
+                        if (mut != null)
+                            body[j] = mut;
                     }
                 }
             }
         }
-        return true; 
+        return true;
     }
 
     //Enumeration...
-    SqueakObject nextInstance(int startingIndex, SqueakObject sqClass) 
-    {
+    SqueakObject nextInstance(int startingIndex, SqueakObject sqClass) {
         //if sqClass is null, then find next object, else find next instance of sqClass
-        for(int i=startingIndex; i<=otMaxUsed; i++) 
-        {
+        for (int i = startingIndex; i <= otMaxUsed; i++) {
             // For every object...
-            SqueakObject obj= (SqueakObject)objectTable[i].get();
-            if (obj != null && (sqClass==null | obj.sqClass == sqClass)) 
-            {
-                lastOTindex= i; // save hint for next scan
+            SqueakObject obj = (SqueakObject) objectTable[i].get();
+            if (obj != null && (sqClass == null | obj.sqClass == sqClass)) {
+                lastOTindex = i; // save hint for next scan
                 return obj;
             }
         }
         return vm.nilObj;  // Return nil if none found
     }
-    
-    int otIndexOfObject(SqueakObject lastObj) 
-    {
+
+    int otIndexOfObject(SqueakObject lastObj) {
         // hint: lastObj should be at lastOTindex
-        SqueakObject obj= (SqueakObject)objectTable[lastOTindex].get(); 
-        if (lastOTindex<=otMaxUsed && obj==lastObj) 
-        {
+        SqueakObject obj = (SqueakObject) objectTable[lastOTindex].get();
+        if (lastOTindex <= otMaxUsed && obj == lastObj) {
             return lastOTindex;
-        }
-        else 
-        {
-            for(int i=0; i<=otMaxUsed; i++) 
-            {
+        } else {
+            for (int i = 0; i <= otMaxUsed; i++) {
                 // Alas no; have to find it again...
-                obj= (SqueakObject)objectTable[i].get();
-                if (obj == lastObj) 
-                    return i; 
+                obj = (SqueakObject) objectTable[i].get();
+                if (obj == lastObj)
+                    return i;
             }
         }
         return -1;  //should not happen
     }
-    
-    private final static int OTMinSize= 30000;
-    private final static int OTMaxSize= 60000;
-    private final static int OTGrowSize= 10000;
-    
-    public short registerObject (SqueakObject obj) 
-    {
+
+    private final static int OTMinSize = 30000;
+    private final static int OTMaxSize = 60000;
+    private final static int OTGrowSize = 10000;
+
+    public short registerObject(SqueakObject obj) {
         //All enumerable objects must be registered
-        if ((otMaxUsed+1) >= objectTable.length)
+        if ((otMaxUsed + 1) >= objectTable.length)
             if (!getMoreOops(OTGrowSize))
                 throw new RuntimeException("Object table has reached capacity");
-        objectTable[++otMaxUsed]= new WeakReference(obj);
-        lastHash= 13849 + (27181 * lastHash);
-        return (short) (lastHash & 0xFFF); 
+        objectTable[++otMaxUsed] = new WeakReference(obj);
+        lastHash = 13849 + (27181 * lastHash);
+        return (short) (lastHash & 0xFFF);
     }
-    
-    private boolean getMoreOops(int request) 
-    {
+
+    private boolean getMoreOops(int request) {
         int nullCount;
-        int startingOtMaxUsed= otMaxUsed;
-        for(int i=0; i<5; i++) 
-        {
-            if (i==2) 
+        int startingOtMaxUsed = otMaxUsed;
+        for (int i = 0; i < 5; i++) {
+            if (i == 2)
                 vm.clearCaches(); //only flush caches after two tries
             partialGC();
-            nullCount= startingOtMaxUsed - otMaxUsed;
+            nullCount = startingOtMaxUsed - otMaxUsed;
             if (nullCount >= request)
-                return true; 
+                return true;
         }
-        
+
         // Sigh -- really need more space...
-        int n= objectTable.length;
-        if (n+request > OTMaxSize) 
-        {
+        int n = objectTable.length;
+        if (n + request > OTMaxSize) {
             fullGC();
-            return false; 
+            return false;
         }
-        System.out.println("Squeak: growing to " + (n+request) + " objects...");
-        WeakReference newTable[]= new WeakReference[n+request];
+        System.out.println("Squeak: growing to " + (n + request) + " objects...");
+        WeakReference newTable[] = new WeakReference[n + request];
         System.arraycopy(objectTable, 0, newTable, 0, n);
-        objectTable= newTable;
-        return true; 
+        objectTable = newTable;
+        return true;
     }
-    
-    int partialGC() 
-    {
+
+    int partialGC() {
         System.gc();
-        otMaxUsed=reclaimNullOTSlots(otMaxOld);
-        return spaceLeft(); 
+        otMaxUsed = reclaimNullOTSlots(otMaxOld);
+        return spaceLeft();
     }
 
-    int spaceLeft() 
-    {
-        return (int)Math.min(Runtime.getRuntime().freeMemory(),(long)SqueakVM.maxSmallInt); 
+    int spaceLeft() {
+        return (int) Math.min(Runtime.getRuntime().freeMemory(), (long) SqueakVM.maxSmallInt);
     }
 
-    int fullGC() 
-    {
+    int fullGC() {
         vm.clearCaches();
-        for(int i=0; i<5; i++) partialGC();
-        otMaxUsed=reclaimNullOTSlots(0);
-        otMaxOld= Math.min(otMaxOld,otMaxUsed);
-        return spaceLeft(); 
+        for (int i = 0; i < 5; i++) partialGC();
+        otMaxUsed = reclaimNullOTSlots(0);
+        otMaxOld = Math.min(otMaxOld, otMaxUsed);
+        return spaceLeft();
     }
 
-    private int reclaimNullOTSlots(int start) 
-    {
+    private int reclaimNullOTSlots(int start) {
         // Java GC will null out slots in the weak Object Table.
         // This procedure compacts the occupied slots (retaining order),
         // and returns a new value for otMaxUsed.
         // If start=0, all are scanned (like full gc);
         // if start=otMaxOld it will skip the old objects (like gcMost).
-        int oldOtMaxUsed= otMaxUsed;
-        int writePtr= start;
-        for(int readPtr= start; readPtr<=otMaxUsed; readPtr++)
+        int oldOtMaxUsed = otMaxUsed;
+        int writePtr = start;
+        for (int readPtr = start; readPtr <= otMaxUsed; readPtr++)
             if (objectTable[readPtr].get() != null)
-                objectTable[writePtr++]=objectTable[readPtr];
-        if (writePtr==start) 
+                objectTable[writePtr++] = objectTable[readPtr];
+        if (writePtr == start)
             return oldOtMaxUsed;
-        return writePtr-1; 
+        return writePtr - 1;
     }
-    
-    private void writeImage (DataOutput ser) throws IOException 
-    {
+
+    private void writeImage(DataOutput ser) throws IOException {
         // Later...
-        throw new IOException( "Image saving is not implemented yet" );
-    } 
-    
-    private void readImage(DataInput in) throws IOException 
-    {
+        throw new IOException("Image saving is not implemented yet");
+    }
+
+    private void readImage(DataInput in) throws IOException {
         //System.err.println("-3.0" + Double.doubleToLongBits(-3.0d));
         System.out.println("Start reading at " + System.currentTimeMillis());
         objectTable = new WeakReference[OTMinSize];
-        otMaxUsed= -1;
-        Hashtable oopMap= new Hashtable(30000);
-        boolean doSwap= false;
-        int version= intFromInputSwapped(in, doSwap);
-        if (version != 6502) 
-        {
-            version= swapInt(version);
+        otMaxUsed = -1;
+        Hashtable oopMap = new Hashtable(30000);
+        boolean doSwap = false;
+        int version = intFromInputSwapped(in, doSwap);
+        if (version != 6502) {
+            version = swapInt(version);
             if (version != 6502)
                 throw new IOException("bad image version");
-            doSwap= true; 
+            doSwap = true;
         }
         System.err.println("version passes with swap= " + doSwap);
-        int headerSize= intFromInputSwapped(in, doSwap);
-        int endOfMemory= intFromInputSwapped(in, doSwap); //first unused location in heap
-        int oldBaseAddr= intFromInputSwapped(in, doSwap); //object memory base address of image
-        int specialObjectsOopInt= intFromInputSwapped(in, doSwap); //oop of array of special oops
-        lastHash= intFromInputSwapped(in, doSwap); //Should be loaded from, and saved to the image header
-        int savedWindowSize= intFromInputSwapped(in, doSwap);
-        int fullScreenFlag= intFromInputSwapped(in, doSwap);
-        int extraVMMemory= intFromInputSwapped(in, doSwap);
-        in.skipBytes(headerSize - (9*4)); //skip to end of header
-        
-        for (int i= 0; i<endOfMemory;) 
-        {
-            int nWords= 0;
-            int classInt= 0;
+        int headerSize = intFromInputSwapped(in, doSwap);
+        int endOfMemory = intFromInputSwapped(in, doSwap); //first unused location in heap
+        int oldBaseAddr = intFromInputSwapped(in, doSwap); //object memory base address of image
+        int specialObjectsOopInt = intFromInputSwapped(in, doSwap); //oop of array of special oops
+        lastHash = intFromInputSwapped(in, doSwap); //Should be loaded from, and saved to the image header
+        int savedWindowSize = intFromInputSwapped(in, doSwap);
+        int fullScreenFlag = intFromInputSwapped(in, doSwap);
+        int extraVMMemory = intFromInputSwapped(in, doSwap);
+        in.skipBytes(headerSize - (9 * 4)); //skip to end of header
+
+        for (int i = 0; i < endOfMemory; ) {
+            int nWords = 0;
+            int classInt = 0;
             int[] data;
-            int format= 0;
-            int hash= 0;
-            int header= intFromInputSwapped(in, doSwap);
-            switch (header & Squeak.HeaderTypeMask) 
-            {
+            int format = 0;
+            int hash = 0;
+            int header = intFromInputSwapped(in, doSwap);
+            switch (header & Squeak.HeaderTypeMask) {
                 case Squeak.HeaderTypeSizeAndClass:
-                    nWords= header>>2;
-                    classInt= intFromInputSwapped(in, doSwap) - Squeak.HeaderTypeSizeAndClass;
-                    header= intFromInputSwapped(in, doSwap);
-                    i= i+12;
+                    nWords = header >> 2;
+                    classInt = intFromInputSwapped(in, doSwap) - Squeak.HeaderTypeSizeAndClass;
+                    header = intFromInputSwapped(in, doSwap);
+                    i = i + 12;
                     break;
                 case Squeak.HeaderTypeClass:
-                    classInt= header - Squeak.HeaderTypeClass;
-                    header= intFromInputSwapped(in, doSwap);
-                    i= i+8;
-                    nWords= (header>>2) & 63;
+                    classInt = header - Squeak.HeaderTypeClass;
+                    header = intFromInputSwapped(in, doSwap);
+                    i = i + 8;
+                    nWords = (header >> 2) & 63;
                     break;
                 case Squeak.HeaderTypeFree:
                     throw new IOException("Unexpected free block");
                 case Squeak.HeaderTypeShort:
-                    i= i+4;
-                    classInt= (header>>12) & 31; //compact class index
+                    i = i + 4;
+                    classInt = (header >> 12) & 31; //compact class index
                     //Note classInt<32 implies compact class index
-                    nWords= (header>>2) & 63;
+                    nWords = (header >> 2) & 63;
                     break;
             }
-            int baseAddr= i - 4; //0-rel byte oop of this object (base header)
+            int baseAddr = i - 4; //0-rel byte oop of this object (base header)
             nWords--;  //length includes base header which we have already read
-            format= ((header>>8) & 15);
-            hash= ((header>>17) & 4095);
-            
+            format = ((header >> 8) & 15);
+            hash = ((header >> 17) & 4095);
+
             // Note classInt and data are just raw data; no base addr adjustment and no Int conversion
-            data= new int[nWords];
-            for (int j= 0; j<nWords; j++)
-                data[j]= intFromInputSwapped(in, doSwap);
-            i= i+(nWords*4);
-            
-            SqueakObject javaObject= new SqueakObject(new Integer (classInt),(short)format,(short)hash,data);
+            data = new int[nWords];
+            for (int j = 0; j < nWords; j++)
+                data[j] = intFromInputSwapped(in, doSwap);
+            i = i + (nWords * 4);
+
+            SqueakObject javaObject = new SqueakObject(new Integer(classInt), (short) format, (short) hash, data);
             registerObject(javaObject);
             //oopMap is from old oops to new objects
             //Why can't we use ints as keys??...
-            oopMap.put(new Integer(baseAddr+oldBaseAddr),javaObject); 
+            oopMap.put(new Integer(baseAddr + oldBaseAddr), javaObject);
         }
-        
+
         //Temp version of spl objs needed for makeCCArray; not a good object yet
-        specialObjectsArray= (SqueakObject)(oopMap.get(new Integer(specialObjectsOopInt)));
-        Integer[] ccArray= makeCCArray(oopMap,specialObjectsArray);
-        int oldOop= specialObjectsArray.oldOopAt(Squeak.splOb_ClassFloat);
-        SqueakObject floatClass= ((SqueakObject) oopMap.get(new Integer(oldOop)));
+        specialObjectsArray = (SqueakObject) (oopMap.get(new Integer(specialObjectsOopInt)));
+        Integer[] ccArray = makeCCArray(oopMap, specialObjectsArray);
+        int oldOop = specialObjectsArray.oldOopAt(Squeak.splOb_ClassFloat);
+        SqueakObject floatClass = ((SqueakObject) oopMap.get(new Integer(oldOop)));
         System.out.println("Start installs at " + System.currentTimeMillis());
-        for (int i= 0; i<otMaxUsed; i++) 
-        {
+        for (int i = 0; i < otMaxUsed; i++) {
             // Don't need oldBaseAddr here**
-            ((SqueakObject) objectTable[i].get()).install(oopMap,ccArray,floatClass); 
+            ((SqueakObject) objectTable[i].get()).install(oopMap, ccArray, floatClass);
         }
-        
+
         System.out.println("Done installing at " + System.currentTimeMillis());
         //Proper version of spl objs -- it's a good object
-        specialObjectsArray= (SqueakObject)(oopMap.get(new Integer(specialObjectsOopInt)));
-        otMaxOld= otMaxUsed; 
+        specialObjectsArray = (SqueakObject) (oopMap.get(new Integer(specialObjectsOopInt)));
+        otMaxOld = otMaxUsed;
     }
-    
-    private int intFromInputSwapped (DataInput in, boolean doSwap) throws IOException 
-    {
+
+    private int intFromInputSwapped(DataInput in, boolean doSwap) throws IOException {
         // Return an int from stream 'in', swizzled if doSwap is true
-        if (doSwap) 
+        if (doSwap)
             return swapInt(in.readInt());
-        else 
-            return in.readInt(); 
+        else
+            return in.readInt();
     }
-    
-    private int swapInt (int toSwap) 
-    {
+
+    private int swapInt(int toSwap) {
         // Return an int with byte order reversed
-        int incoming= toSwap;
-        int outgoing= 0;
-        for (int i= 0; i<4; i++) 
-        {
-            int lowByte= incoming & 255;
-            outgoing= (outgoing<<8) + lowByte;
-            incoming= incoming>>8; 
+        int incoming = toSwap;
+        int outgoing = 0;
+        for (int i = 0; i < 4; i++) {
+            int lowByte = incoming & 255;
+            outgoing = (outgoing << 8) + lowByte;
+            incoming = incoming >> 8;
         }
-        return outgoing; 
+        return outgoing;
     }
-        
-    private Integer[] makeCCArray(Hashtable oopMap, SqueakObject splObs) 
-    {
+
+    private Integer[] makeCCArray(Hashtable oopMap, SqueakObject splObs) {
         //Makes an aray of the complact classes as oldOops (still need to be mapped)
-        int oldOop= splObs.oldOopAt(Squeak.splOb_CompactClasses);
-        SqueakObject compactClassesArray= ((SqueakObject) oopMap.get(new Integer(oldOop)));
-        Integer[] ccArray= new Integer[31];
-        for (int i= 0; i<31; i++) 
-        {
-            ccArray[i]= new Integer (compactClassesArray.oldOopAt(i)); 
+        int oldOop = splObs.oldOopAt(Squeak.splOb_CompactClasses);
+        SqueakObject compactClassesArray = ((SqueakObject) oopMap.get(new Integer(oldOop)));
+        Integer[] ccArray = new Integer[31];
+        for (int i = 0; i < 31; i++) {
+            ccArray[i] = new Integer(compactClassesArray.oldOopAt(i));
         }
-        return ccArray; 
+        return ccArray;
     }
 }

--- a/src/JSqueak/SqueakObject.java
+++ b/src/JSqueak/SqueakObject.java
@@ -28,13 +28,13 @@ import java.util.Hashtable;
 
 /**
  * @author Daniel Ingalls
- *
+ * <p>
  * Squeak objects are modelled by Java objects with separate binary and pointer data.
  * Later this could be optimized for objects that have only one or the other, but for
  * now it is simple, and handles the inhomogeneous case of CompiledMethods nicely.
- *
+ * <p>
  * Weak fields are not currently supported.  The plan for doing this would be
- * to make those objects a subclass, and put pointers in a WeakField.  We would 
+ * to make those objects a subclass, and put pointers in a WeakField.  We would
  * need to replace all patterns of obj.pointers with an access function.
  * Then we would associate a finalization routine with those pointers.
  */
@@ -45,47 +45,38 @@ public class SqueakObject //Later make variants for common formats
     Object sqClass;  //squeak class
     Object[] pointers; //pointer fields; fixed as well as indexable
     Object bits;       //indexable binary data (bytes or ints)
-    
-    SqueakObject(Integer cls, int fmt, int hsh, int[] imageData) 
-    {
+
+    SqueakObject(Integer cls, int fmt, int hsh, int[] imageData) {
         //Initial creation from SqueakImage, with unmapped data
-        sqClass= cls;
-        format= (short)fmt;
-        hash= (short)hsh;
-        bits= imageData; 
+        sqClass = cls;
+        format = (short) fmt;
+        hash = (short) hsh;
+        bits = imageData;
     }
 
-    SqueakObject(SqueakImage img) 
-    {
+    SqueakObject(SqueakImage img) {
         //Creation of stub object (no pointers or bits)
-        hash= img.registerObject(this); 
+        hash = img.registerObject(this);
     }
 
-    SqueakObject(SqueakImage img, SqueakObject cls, int indexableSize, SqueakObject filler) 
-    {
+    SqueakObject(SqueakImage img, SqueakObject cls, int indexableSize, SqueakObject filler) {
         //Creation of objects from Squeak
         this(img);
-        sqClass= cls;
-        int instSpec= SqueakVM.intFromSmall(cls.getPointerI(Squeak.Class_format));
-        int instSize= ((instSpec>>1) & 0x3F) + ((instSpec>>10) & 0xC0) - 1; //0-255
-        format= ((short) ((instSpec>>7) & 0xF)); //This is the 0-15 code
-        
-        if (format<8) 
-        {
-            if (format!=6) 
-            {
-                pointers= new Object[instSize+indexableSize];
-                Arrays.fill(pointers,filler); 
+        sqClass = cls;
+        int instSpec = SqueakVM.intFromSmall(cls.getPointerI(Squeak.Class_format));
+        int instSize = ((instSpec >> 1) & 0x3F) + ((instSpec >> 10) & 0xC0) - 1; //0-255
+        format = ((short) ((instSpec >> 7) & 0xF)); //This is the 0-15 code
+
+        if (format < 8) {
+            if (format != 6) {
+                pointers = new Object[instSize + indexableSize];
+                Arrays.fill(pointers, filler);
+            } else {
+                if (indexableSize >= 0)
+                    bits = new int[indexableSize];
             }
-            else
-            {
-                if (indexableSize>=0)
-                    bits= new int[indexableSize]; 
-            }
-        }
-        else
-        {
-            bits= new byte[indexableSize];  //Methods require further init of pointers
+        } else {
+            bits = new byte[indexableSize];  //Methods require further init of pointers
         }
     }
 
@@ -109,197 +100,167 @@ public class SqueakObject //Later make variants for common formats
 
 
     //General access
-    public SqueakObject getSqClass() 
-    {
-        return (SqueakObject) sqClass; 
+    public SqueakObject getSqClass() {
+        return (SqueakObject) sqClass;
     }
-        
-    public Object getPointer(int zeroBasedIndex) 
-    {
-        return pointers[zeroBasedIndex]; 
+
+    public Object getPointer(int zeroBasedIndex) {
+        return pointers[zeroBasedIndex];
     }
-    
-    public SqueakObject getPointerNI(int zeroBasedIndex) 
-    {
+
+    public SqueakObject getPointerNI(int zeroBasedIndex) {
         //Returns only SqueakObjects, not Integers
-        return (SqueakObject) pointers[zeroBasedIndex]; 
+        return (SqueakObject) pointers[zeroBasedIndex];
     }
-    
-    public Integer getPointerI(int zeroBasedIndex) 
-    {
+
+    public Integer getPointerI(int zeroBasedIndex) {
         //Returns only SmallIntegers
-        return (Integer) pointers[zeroBasedIndex]; 
+        return (Integer) pointers[zeroBasedIndex];
     }
-    
-    public void setPointer(int zeroBasedIndex, Object aPointer) 
-    {
-        pointers[zeroBasedIndex]= aPointer; 
+
+    public void setPointer(int zeroBasedIndex, Object aPointer) {
+        pointers[zeroBasedIndex] = aPointer;
     }
-    
-    public int pointersSize() 
-    {
-        return pointers==null? 0 : pointers.length; 
+
+    public int pointersSize() {
+        return pointers == null ? 0 : pointers.length;
     }
-    
-    public int bitsSize() 
-    {
-        if (bits==null) 
+
+    public int bitsSize() {
+        if (bits == null)
             return 0;
-        if (bits instanceof byte[]) 
-            return ((byte[])bits).length;
-        if (bits instanceof Double) 
+        if (bits instanceof byte[])
+            return ((byte[]) bits).length;
+        if (bits instanceof Double)
             return 2;
-        return ((int[])bits).length; 
+        return ((int[]) bits).length;
     }
-    
+
     public int instSize() //same as class.classInstSize, but faster from format
     {
-        if (format>4 || format==2) //indexable fields only 
-            return 0; 
-        if (format<2)  //indexable fields only
+        if (format > 4 || format == 2) //indexable fields only
+            return 0;
+        if (format < 2)  //indexable fields only
             return pointers.length;
-        return ((SqueakObject)sqClass).classInstSize();  //0-255
+        return ((SqueakObject) sqClass).classInstSize();  //0-255
     }
 
-    public int classInstSize() 
-    {
-        int instSpec= SqueakVM.intFromSmall(this.getPointerI(Squeak.Class_format));
-        return ((instSpec>>1) & 0x3F) + ((instSpec>>10) & 0xC0) - 1; //0-255
+    public int classInstSize() {
+        int instSpec = SqueakVM.intFromSmall(this.getPointerI(Squeak.Class_format));
+        return ((instSpec >> 1) & 0x3F) + ((instSpec >> 10) & 0xC0) - 1; //0-255
     }
 
-    public SqueakObject classGetName() 
-    {
-        return this.getPointerNI(Squeak.Class_name); 
+    public SqueakObject classGetName() {
+        return this.getPointerNI(Squeak.Class_name);
     }
-    
-    SqueakObject cloneIn(SqueakImage img) 
-    {
+
+    SqueakObject cloneIn(SqueakImage img) {
         //Need to get new hash, OT entry...
-        SqueakObject clone= new SqueakObject(img);
+        SqueakObject clone = new SqueakObject(img);
         clone.copyStateFrom(this);
-        return clone; 
+        return clone;
     }
-    
-    private void copyStateFrom(SqueakObject other) 
-    {
-        sqClass= other.sqClass;
-        format= other.format;
-        pointers= (Object[])other.pointers.clone();
-        Object otherBits= other.bits;
-        if (otherBits==null)
+
+    private void copyStateFrom(SqueakObject other) {
+        sqClass = other.sqClass;
+        format = other.format;
+        pointers = (Object[]) other.pointers.clone();
+        Object otherBits = other.bits;
+        if (otherBits == null)
             return;
         if (otherBits instanceof byte[])
-            bits= ((byte[])other.bits).clone();
+            bits = ((byte[]) other.bits).clone();
         else if (otherBits instanceof int[])
-            bits= ((int[])other.bits).clone(); 
-    }
-        
-    double getFloatBits()  // isn't this slow?'
-    {
-        return ((Double)bits).doubleValue(); 
-    }
-    
-    void setFloatBits(double value) 
-    {
-        bits= new Double(value); 
-    }
-    
-    //CompiledMethods
-    public int methodHeader() 
-    {
-        return ((Integer)getPointer(0)).intValue(); 
-    }
-    
-    public int methodNumLits() 
-    {
-        return (methodHeader()>>9)&0xFF; 
-    }
-    
-    public int methodNumArgs() 
-    {
-        return (methodHeader()>>24)&0xF; 
-    }
-    
-    public int methodPrimitiveIndex() 
-    {
-        int primBits= (methodHeader())&0x300001FF;
-        if (primBits > 0x1FF)
-            return (primBits & 0x1FF) + (primBits >> 19);
-        else 
-            return primBits; 
-    }
-    
-    public SqueakObject methodClassForSuper() //assn found in last literal
-    {
-        SqueakObject assn= getPointerNI(methodNumLits());
-        return assn.getPointerNI(Squeak.Assn_value); 
-    }
-    
-    public boolean methodNeedsLargeFrame() 
-    {
-        return (methodHeader() & 0x20000) > 0; 
+            bits = ((int[]) other.bits).clone();
     }
 
-    public void methodAddPointers(Object[] headerAndLits) 
+    double getFloatBits()  // isn't this slow?'
     {
-        pointers= headerAndLits; 
+        return ((Double) bits).doubleValue();
     }
-    
-    public int methodTempCount() 
-    {
-        return (methodHeader()>>18) & 63; 
+
+    void setFloatBits(double value) {
+        bits = new Double(value);
     }
-    
-    public Object methodGetLiteral(int zeroBasedIndex) 
-    {
-        return getPointer(1+zeroBasedIndex);  // step over header
+
+    //CompiledMethods
+    public int methodHeader() {
+        return ((Integer) getPointer(0)).intValue();
     }
-    
-    
-    public SqueakObject methodGetSelector(int zeroBasedIndex) 
-    {
-        return getPointerNI(1+zeroBasedIndex); // step over header
+
+    public int methodNumLits() {
+        return (methodHeader() >> 9) & 0xFF;
     }
-    
-    public void methodSetLiteral(int zeroBasedIndex, Object rawValue) 
-    {
-        setPointer(1+zeroBasedIndex, rawValue); // step over header
+
+    public int methodNumArgs() {
+        return (methodHeader() >> 24) & 0xF;
     }
-    
-    //Methods below here are only used for reading the Squeak image format
-    public void install(Hashtable oopMap, Integer[] ccArray, SqueakObject floatClass) 
-    {
-        //Install this object by decoding format, and rectifying pointers
-        int ccInt= ((Integer)sqClass).intValue();
-        if ((ccInt>0) && (ccInt<32))
-            sqClass= oopMap.get(ccArray[ccInt-1]);
+
+    public int methodPrimitiveIndex() {
+        int primBits = (methodHeader()) & 0x300001FF;
+        if (primBits > 0x1FF)
+            return (primBits & 0x1FF) + (primBits >> 19);
         else
-            sqClass= oopMap.get(sqClass);
-        int nWords= ((int[]) bits).length;
-        if (format<5) 
-        {
+            return primBits;
+    }
+
+    public SqueakObject methodClassForSuper() //assn found in last literal
+    {
+        SqueakObject assn = getPointerNI(methodNumLits());
+        return assn.getPointerNI(Squeak.Assn_value);
+    }
+
+    public boolean methodNeedsLargeFrame() {
+        return (methodHeader() & 0x20000) > 0;
+    }
+
+    public void methodAddPointers(Object[] headerAndLits) {
+        pointers = headerAndLits;
+    }
+
+    public int methodTempCount() {
+        return (methodHeader() >> 18) & 63;
+    }
+
+    public Object methodGetLiteral(int zeroBasedIndex) {
+        return getPointer(1 + zeroBasedIndex);  // step over header
+    }
+
+
+    public SqueakObject methodGetSelector(int zeroBasedIndex) {
+        return getPointerNI(1 + zeroBasedIndex); // step over header
+    }
+
+    public void methodSetLiteral(int zeroBasedIndex, Object rawValue) {
+        setPointer(1 + zeroBasedIndex, rawValue); // step over header
+    }
+
+    //Methods below here are only used for reading the Squeak image format
+    public void install(Hashtable oopMap, Integer[] ccArray, SqueakObject floatClass) {
+        //Install this object by decoding format, and rectifying pointers
+        int ccInt = ((Integer) sqClass).intValue();
+        if ((ccInt > 0) && (ccInt < 32))
+            sqClass = oopMap.get(ccArray[ccInt - 1]);
+        else
+            sqClass = oopMap.get(sqClass);
+        int nWords = ((int[]) bits).length;
+        if (format < 5) {
             //Formats 0...4 -- Pointer fields
-            pointers= decodePointers(nWords,((int[])bits),oopMap);
-            bits= null; 
-        }
-        else 
-        {
-            if (format>=12) 
-            {
+            pointers = decodePointers(nWords, ((int[]) bits), oopMap);
+            bits = null;
+        } else {
+            if (format >= 12) {
                 //Formats 12-15 -- CompiledMethods both pointers and bits
-                int methodHeader= ((int[])bits)[0];
-                int numLits= (methodHeader>>10)&255;
-                pointers= decodePointers(numLits+1,((int[])bits),oopMap); //header+lits
-                bits= decodeBytes(nWords-(numLits+1),((int[])bits),numLits+1,format&3); 
-            }
-            else if (format>=8) 
-            {
+                int methodHeader = ((int[]) bits)[0];
+                int numLits = (methodHeader >> 10) & 255;
+                pointers = decodePointers(numLits + 1, ((int[]) bits), oopMap); //header+lits
+                bits = decodeBytes(nWords - (numLits + 1), ((int[]) bits), numLits + 1, format & 3);
+            } else if (format >= 8) {
                 //Formats 8..11 -- ByteArrays (and Strings)
-                bits= decodeBytes(nWords,((int[])bits),0,format&3); 
+                bits = decodeBytes(nWords, ((int[]) bits), 0, format & 3);
             }
             //Format 6 word objects are already OK (except Floats...)
-            else if (sqClass==floatClass) 
-            {
+            else if (sqClass == floatClass) {
                 //Floats need two ints to be converted to double
                 long higherBits = ((long) ((int[]) bits)[0]) << 32;
                 //Use unsigned right shift operator to ignore negative sign
@@ -312,87 +273,75 @@ public class SqueakObject //Later make variants for common formats
         }
     }
 
-    private Object[] decodePointers(int nWords,int[]theBits,Hashtable oopMap) 
-    {
+    private Object[] decodePointers(int nWords, int[] theBits, Hashtable oopMap) {
         //Convert small ints and look up object pointers in oopMap
-        Object[] ptrs= new Object[nWords];
-        for (int i=0; i<nWords; i++) 
-        {
-            int oldOop= theBits[i];
-            if ((oldOop&1)==1)
-                ptrs[i]= SqueakVM.smallFromInt(oldOop>>1);
+        Object[] ptrs = new Object[nWords];
+        for (int i = 0; i < nWords; i++) {
+            int oldOop = theBits[i];
+            if ((oldOop & 1) == 1)
+                ptrs[i] = SqueakVM.smallFromInt(oldOop >> 1);
             else
-                ptrs[i]= oopMap.get(new Integer (oldOop)); 
+                ptrs[i] = oopMap.get(new Integer(oldOop));
         }
-        return ptrs; 
+        return ptrs;
     }
 
-    private byte[] decodeBytes(int nWords,int[]theBits,int wordOffset,int fmtLoBits) 
-    {
+    private byte[] decodeBytes(int nWords, int[] theBits, int wordOffset, int fmtLoBits) {
         //Adjust size for low bits and extract bytes from ints
-        int nBytes= (nWords*4) - (format&3);
-        byte[]newBits= new byte[nBytes];
-        int wordIx= wordOffset;
-        int fourBytes= 0;
-        for (int i=0; i<nBytes; i++) 
-        {
-            if ((i&3)==0)
-                fourBytes= theBits[wordIx++];
-            int pickByte= (fourBytes>>(8*(3-(i&3))))&255;
-            if (pickByte>=128)
-                pickByte= pickByte-256;
-            newBits[i]= (byte) pickByte; 
+        int nBytes = (nWords * 4) - (format & 3);
+        byte[] newBits = new byte[nBytes];
+        int wordIx = wordOffset;
+        int fourBytes = 0;
+        for (int i = 0; i < nBytes; i++) {
+            if ((i & 3) == 0)
+                fourBytes = theBits[wordIx++];
+            int pickByte = (fourBytes >> (8 * (3 - (i & 3)))) & 255;
+            if (pickByte >= 128)
+                pickByte = pickByte - 256;
+            newBits[i] = (byte) pickByte;
         }
-        return newBits; 
+        return newBits;
     }
 
-    public int oldOopAt(int zeroBasedOffset) 
-    {
-        return ((int[]) bits)[zeroBasedOffset]; 
+    public int oldOopAt(int zeroBasedOffset) {
+        return ((int[]) bits)[zeroBasedOffset];
     }
-    
-    public String asString() 
-    {
+
+    public String asString() {
         // debugging only: if body consists of bytes, make a Java String from them
-        if (bits != null && bits instanceof byte[]) 
-        {
-            if (pointers != null) 
+        if (bits != null && bits instanceof byte[]) {
+            if (pointers != null)
                 return "a CompiledMethod";
-            else 
-                return new String((byte[])bits); 
-        }
-        else 
-        {
-            SqueakObject itsClass= this.getSqClass();
+            else
+                return new String((byte[]) bits);
+        } else {
+            SqueakObject itsClass = this.getSqClass();
             if (itsClass.pointersSize() >= 9)
                 return "a " + itsClass.classGetName().asString();
-            else 
-                return "Class " + this.classGetName().asString(); 
+            else
+                return "Class " + this.classGetName().asString();
         }
     }
-    
-    public String toString() 
-    {
-        return this.asString(); 
+
+    public String toString() {
+        return this.asString();
     }
-    
+
     /**
      * FIXME: what is the right way to achieve this?
      */
-    void setByte( int zeroBasedIndex, byte value )
-    {
+    void setByte(int zeroBasedIndex, byte value) {
         byte[] bytes = (byte[]) bits;
-        
-        bytes[ zeroBasedIndex ] = value;
+
+        bytes[zeroBasedIndex] = value;
     }
-    
+
     /**
      * FIXME: what is the right way to achieve this?
      */
-    byte getByte( int zeroBasedIndex )
-    {
+    byte getByte(int zeroBasedIndex) {
         byte[] bytes = (byte[]) bits;
-        
-        return bytes[ zeroBasedIndex ];
+
+        return bytes[zeroBasedIndex];
     }
 }

--- a/src/JSqueak/SqueakPrimitiveHandler.java
+++ b/src/JSqueak/SqueakPrimitiveHandler.java
@@ -49,7 +49,6 @@ class SqueakPrimitiveHandler {
     private Screen theDisplay;
     private int[] displayBitmap;
     private int displayRaster;
-    private byte[] displayBitmapInBytes;
     private int BWMask = 0;
 
 
@@ -1336,10 +1335,7 @@ class SqueakPrimitiveHandler {
                                                     }
             );
         }
-        displayBitmapInBytes = new byte[displayBitmap.length * 4];
-        copyBitmapToByteArray(displayBitmap, displayBitmapInBytes,
-                new Rectangle(0, 0, disp.width, disp.height), disp.pitch, disp.depth);
-        theDisplay.setBits(displayBitmapInBytes, disp.depth);
+        theDisplay.setBits(displayBitmap, disp.depth);
         if (!remap)
             theDisplay.open();
     }
@@ -1406,8 +1402,6 @@ class SqueakPrimitiveHandler {
 
         Rectangle affectedArea = bitbltTable.copyBits();
         if (affectedArea != null && theDisplay != null) {
-            copyBitmapToByteArray(displayBitmap, displayBitmapInBytes, affectedArea,
-                    bitbltTable.dest.pitch, bitbltTable.dest.depth);
             theDisplay.redisplay(false, affectedArea);
         }
         if (bitbltTable.combinationRule == 22 || bitbltTable.combinationRule == 32)
@@ -1429,11 +1423,12 @@ class SqueakPrimitiveHandler {
             }
         }
 
-        //        int word;
-        //        for(int i=0; i<words.length; i++) {
-        //            word= ~(words[i]);
-        //            for(int j=0; j<4; j++)
-        //                bytes[(i*4)+j]= (byte)((word>>>((3-j)*8))&255); }
+        /*int word;
+        for (int i = 0; i < words.length; i++) {
+            word = ~(words[i]);
+            for (int j = 0; j < 4; j++)
+                bytes[(i * 4) + j] = (byte) ((word >>> ((3 - j) * 8)) );
+        }*/
     }
 
     private SqueakObject primitiveMousePoint() {

--- a/src/JSqueak/SqueakPrimitiveHandler.java
+++ b/src/JSqueak/SqueakPrimitiveHandler.java
@@ -23,6 +23,8 @@ THE SOFTWARE.
 
 package JSqueak;
 
+import JSqueak.utils.SqueakLogger;
+
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -413,7 +415,7 @@ class SqueakPrimitiveHandler {
                     popNandPush(5, primitiveStringReplace()); // string and array replace
                     break;
                 case 106:
-                    popNandPush(1, makePointWithXandY(SqueakVM.smallFromInt(640), SqueakVM.smallFromInt(480))); // actualScreenSize // FIXME: Use real size
+                    primitiveScreenSize();
                     break;
                 case 107:
                     popNandPush(1, primitiveMouseButtons()); // Sensor mouseButtons
@@ -1484,6 +1486,23 @@ class SqueakPrimitiveHandler {
     private SqueakObject primitiveNextInstance(SqueakObject priorInstance) {
         SqueakObject sqClass = (SqueakObject) priorInstance.sqClass;
         return image.nextInstance(image.otIndexOfObject(priorInstance) + 1, sqClass);
+    }
+
+    private boolean primitiveScreenSize() {
+        int width = 640;
+        int height = 480;
+        if (theDisplay != null && theDisplay.fExtent != null) {
+            width = theDisplay.fExtent.width;
+            height = theDisplay.fExtent.height;
+        }
+        SqueakLogger.log_D("primitiveScreenSize width: " + width + " height: " + height);
+        try {
+            popNandPush(1, makePointWithXandY(SqueakVM.smallFromInt(width), SqueakVM.smallFromInt(height))); // actualScreenSize
+        } catch (Exception e) {
+            throw PrimitiveFailed;
+        }
+
+        return true;
     }
 
     private boolean relinquishProcessor() {

--- a/src/JSqueak/SqueakPrimitiveHandler.java
+++ b/src/JSqueak/SqueakPrimitiveHandler.java
@@ -34,448 +34,534 @@ import java.util.Arrays;
 
 /**
  * @author Daniel Ingalls
- *
+ * <p>
  * Implements the indexed primitives for the Squeak VM.
  */
-class SqueakPrimitiveHandler 
-{
+class SqueakPrimitiveHandler {
     private final PrimitiveFailedException PrimitiveFailed = new PrimitiveFailedException();
-    
+
     private final SqueakVM vm;
     private final SqueakImage image;
     private final BitBlt bitbltTable;
 
-    private final FileSystemPrimitives fileSystemPrimitives = new FileSystemPrimitives( this );
-    
+    private final FileSystemPrimitives fileSystemPrimitives = new FileSystemPrimitives(this);
+
     private Screen theDisplay;
     private int[] displayBitmap;
     private int displayRaster;
     private byte[] displayBitmapInBytes;
-    private int BWMask= 0;
-    
-    
+    private int BWMask = 0;
+
+
     // Its purpose of the at-cache is to allow fast (bytecode) access to at/atput code
     // without having to check whether this object has overridden at, etc.
-    private final int atCacheSize= 32; // must be power of 2
-    private final int atCacheMask= atCacheSize-1; //...so this is a mask
-    
+    private final int atCacheSize = 32; // must be power of 2
+    private final int atCacheMask = atCacheSize - 1; //...so this is a mask
+
     private AtCacheInfo[] atCache;
     private AtCacheInfo[] atPutCache;
     private AtCacheInfo nonCachedInfo;
-    
-    SqueakPrimitiveHandler(SqueakVM theVM) 
-    {
-        vm= theVM;
-        image= vm.image;
-        bitbltTable= new BitBlt(vm);
-        initAtCache(); 
-    }
-    
-    /**
-     * A singleton instance of this class should be thrown to signal that a 
-     * primitive has failed.
-     */
-    private static class PrimitiveFailedException extends RuntimeException 
-    {
+
+    SqueakPrimitiveHandler(SqueakVM theVM) {
+        vm = theVM;
+        image = vm.image;
+        bitbltTable = new BitBlt(vm);
+        initAtCache();
     }
 
-    private static class AtCacheInfo 
-    {
+    /**
+     * A singleton instance of this class should be thrown to signal that a
+     * primitive has failed.
+     */
+    private static class PrimitiveFailedException extends RuntimeException {
+    }
+
+    private static class AtCacheInfo {
         SqueakObject array;
         int size;
         int ivarOffset;
-        boolean convertChars; 
+        boolean convertChars;
     }
-    
-    private void initAtCache() 
-    {
-        atCache= new AtCacheInfo[atCacheSize];
-        atPutCache= new AtCacheInfo[atCacheSize];
-        nonCachedInfo= new AtCacheInfo();
-        for(int i= 0; i<atCacheSize; i++)
-        {
-            atCache[i]= new AtCacheInfo();
-            atPutCache[i]= new AtCacheInfo();
-        } 
-    }
-    
-    /**
-     * Clear at-cache pointers (prior to GC). 
-     */
-    void clearAtCache() 
-    {
-        for(int i= 0; i<atCacheSize; i++) 
-        {
-            atCache[i].array= null;
-            atPutCache[i].array= null;
+
+    private void initAtCache() {
+        atCache = new AtCacheInfo[atCacheSize];
+        atPutCache = new AtCacheInfo[atCacheSize];
+        nonCachedInfo = new AtCacheInfo();
+        for (int i = 0; i < atCacheSize; i++) {
+            atCache[i] = new AtCacheInfo();
+            atPutCache[i] = new AtCacheInfo();
         }
     }
-    
-    private AtCacheInfo makeCacheInfo(AtCacheInfo[] atOrPutCache, Object atOrPutSelector, SqueakObject array, boolean convertChars, boolean includeInstVars) 
-    {
+
+    /**
+     * Clear at-cache pointers (prior to GC).
+     */
+    void clearAtCache() {
+        for (int i = 0; i < atCacheSize; i++) {
+            atCache[i].array = null;
+            atPutCache[i].array = null;
+        }
+    }
+
+    private AtCacheInfo makeCacheInfo(AtCacheInfo[] atOrPutCache, Object atOrPutSelector, SqueakObject array, boolean convertChars, boolean includeInstVars) {
         //Make up an info object and store it in the atCache or the atPutCache.
         //If it's not cacheable (not a non-super send of at: or at:put:)
         //then return the info in nonCachedInfo.
         //Note that info for objectAt (includeInstVars) will have
         //a zero ivarOffset, and a size that includes the extra instVars
         AtCacheInfo info;
-        boolean cacheable= (vm.verifyAtSelector == atOrPutSelector) //is at or atPut
-            && (vm.verifyAtClass == array.getSqClass())         //not a super send
-            && (array.format==3 && vm.isContext(array));        //not a context (size can change)
-        if (cacheable) 
-            info= atOrPutCache[array.hashCode() & atCacheMask];
+        boolean cacheable = (vm.verifyAtSelector == atOrPutSelector) //is at or atPut
+                && (vm.verifyAtClass == array.getSqClass())         //not a super send
+                && (array.format == 3 && vm.isContext(array));        //not a context (size can change)
+        if (cacheable)
+            info = atOrPutCache[array.hashCode() & atCacheMask];
         else
-            info= nonCachedInfo;
-        info.array= array;
-        info.convertChars= convertChars; 
-        if (includeInstVars) 
-        {
-            info.size= Math.max(0,indexableSize(array)) + array.instSize();
-            info.ivarOffset= 0; 
+            info = nonCachedInfo;
+        info.array = array;
+        info.convertChars = convertChars;
+        if (includeInstVars) {
+            info.size = Math.max(0, indexableSize(array)) + array.instSize();
+            info.ivarOffset = 0;
+        } else {
+            info.size = indexableSize(array);
+            info.ivarOffset = (array.format < 6) ? array.instSize() : 0;
         }
-        else 
-        {
-            info.size= indexableSize(array);
-            info.ivarOffset= (array.format<6) ? array.instSize() : 0; 
-        }
-        return info; 
+        return info;
     }
-    
+
     // Quick Sends from inner Interpreter
-    boolean quickSendOther(Object rcvr, int lobits) 
-    {
+    boolean quickSendOther(Object rcvr, int lobits) {
         // QuickSendOther returns true if it succeeds
-        try
-        {
-            switch (lobits) 
-            {
-                case 0x0: popNandPush(2,primitiveAt(true,true,false)); // at:
-                          break;
-                case 0x1: popNandPush(3,primitiveAtPut(true,true,false)); // at:put:
-                          break;
-                case 0x2: popNandPush(1,primitiveSize()); // size
-                          break;
-                case 0x3: return false; // next
-                case 0x4: return false; // nextPut
-                case 0x5: return false; // atEnd
-                case 0x6: return pop2andDoBool(primitiveEq(vm.stackValue(1),vm.stackValue(0))); // ==
-                case 0x7: popNandPush(1,vm.getClass(vm.top())); // class
-                          break;
-                case 0x8: popNandPush(2,primitiveBlockCopy()); // blockCopy:
-                          break;
-                case 0x9: primitiveBlockValue(0); // value
-                          break;
-                case 0xa: primitiveBlockValue(1); // value:
-                          break;
-                case 0xb: return false; // do:
-                case 0xc: return false; // new
-                case 0xd: return false; // new:
-                case 0xe: return false; // x
-                case 0xf: return false; // y
-                default: return false; 
+        try {
+            switch (lobits) {
+                case 0x0:
+                    popNandPush(2, primitiveAt(true, true, false)); // at:
+                    break;
+                case 0x1:
+                    popNandPush(3, primitiveAtPut(true, true, false)); // at:put:
+                    break;
+                case 0x2:
+                    popNandPush(1, primitiveSize()); // size
+                    break;
+                case 0x3:
+                    return false; // next
+                case 0x4:
+                    return false; // nextPut
+                case 0x5:
+                    return false; // atEnd
+                case 0x6:
+                    return pop2andDoBool(primitiveEq(vm.stackValue(1), vm.stackValue(0))); // ==
+                case 0x7:
+                    popNandPush(1, vm.getClass(vm.top())); // class
+                    break;
+                case 0x8:
+                    popNandPush(2, primitiveBlockCopy()); // blockCopy:
+                    break;
+                case 0x9:
+                    primitiveBlockValue(0); // value
+                    break;
+                case 0xa:
+                    primitiveBlockValue(1); // value:
+                    break;
+                case 0xb:
+                    return false; // do:
+                case 0xc:
+                    return false; // new
+                case 0xd:
+                    return false; // new:
+                case 0xe:
+                    return false; // x
+                case 0xf:
+                    return false; // y
+                default:
+                    return false;
             }
             return true;
-        }
-        catch ( PrimitiveFailedException exception )
-        {
+        } catch (PrimitiveFailedException exception) {
             return false;
         }
     }
 
-    private static boolean primitiveEq(Object arg1, Object arg2) 
-    {
+    private static boolean primitiveEq(Object arg1, Object arg2) {
         // == must work for uninterned small ints
         if (SqueakVM.isSmallInt(arg1) && SqueakVM.isSmallInt(arg2))
-            return ((Integer)arg1).intValue() == ((Integer)arg2).intValue();
-        return arg1==arg2; 
+            return ((Integer) arg1).intValue() == ((Integer) arg2).intValue();
+        return arg1 == arg2;
     }
-    
-    private Object primitiveBitAnd() 
-    {
+
+    private Object primitiveBitAnd() {
         int rcvr = stackPos32BitValue(1);
-        int arg  = stackPos32BitValue(0);
+        int arg = stackPos32BitValue(0);
 
-        return pos32BitIntFor(rcvr & arg); 
+        return pos32BitIntFor(rcvr & arg);
     }
-    
-    private Object primitiveBitOr() 
-    {
-        int rcvr= stackPos32BitValue(1);
-        int arg= stackPos32BitValue(0);
 
-        return pos32BitIntFor(rcvr | arg); 
-    }
-    
-    private Object primitiveBitXor() 
-    {
-        int rcvr= stackPos32BitValue(1);
-        int arg= stackPos32BitValue(0);
-        
-        return pos32BitIntFor(rcvr ^ arg); 
-    }
-    
-    private Object primitiveBitShift() 
-    {
-        int rcvr= stackPos32BitValue(1);
-        int arg= stackInteger(0);
+    private Object primitiveBitOr() {
+        int rcvr = stackPos32BitValue(1);
+        int arg = stackPos32BitValue(0);
 
-        return pos32BitIntFor(SqueakVM.safeShift(rcvr,arg)); 
+        return pos32BitIntFor(rcvr | arg);
     }
-    
-    private int doQuo(int rcvr, int arg) 
-    {
-        if (arg == 0) 
+
+    private Object primitiveBitXor() {
+        int rcvr = stackPos32BitValue(1);
+        int arg = stackPos32BitValue(0);
+
+        return pos32BitIntFor(rcvr ^ arg);
+    }
+
+    private Object primitiveBitShift() {
+        int rcvr = stackPos32BitValue(1);
+        int arg = stackInteger(0);
+
+        return pos32BitIntFor(SqueakVM.safeShift(rcvr, arg));
+    }
+
+    private int doQuo(int rcvr, int arg) {
+        if (arg == 0)
             throw PrimitiveFailed;
 //            success= false; return 0;  // FIXME: Why doesn't doQuo() return nonSmallInt
-        
-        if (rcvr > 0) 
-        {
-            if (arg > 0) 
+
+        if (rcvr > 0) {
+            if (arg > 0)
                 return rcvr / arg;
-            else 
-                return 0 - (rcvr / (0 - arg)); 
-        }
-        else 
-        {
+            else
+                return 0 - (rcvr / (0 - arg));
+        } else {
             if (arg > 0)
                 return 0 - ((0 - rcvr) / arg);
-            else 
-                return (0 - rcvr) / (0 - arg); 
+            else
+                return (0 - rcvr) / (0 - arg);
         }
     }
-    
-    boolean doPrimitive(int index, int argCount) 
-    {
-        try
-        {
-            switch (index) 
-            {
+
+    boolean doPrimitive(int index, int argCount) {
+        try {
+            switch (index) {
                 // 0..127
-                case 1: popNandPushInt(2,stackInteger(1)+stackInteger(0));  // Integer.add
-                        break;
-                case 2: popNandPushInt(2,stackInteger(1)-stackInteger(0));  // Integer.subtract
-                        break;
-                case 3: return pop2andDoBool(stackInteger(1)<stackInteger(0));  // Integer.less
-                case 4: return pop2andDoBool(stackInteger(1)>stackInteger(0));  // Integer.greater
-                case 5: return pop2andDoBool(stackInteger(1)<=stackInteger(0));  // Integer.leq
-                case 6: return pop2andDoBool(stackInteger(1)>=stackInteger(0));  // Integer.geq
-                case 7: return pop2andDoBool(stackInteger(1)==stackInteger(0));  // Integer.equal
-                case 8: return pop2andDoBool(stackInteger(1)!=stackInteger(0));  // Integer.notequal
-                case 9: popNandPushInt(2,SqueakVM.safeMultiply(stackInteger(1),stackInteger(0)));  // Integer.multiply *
-                        break;
-                case 10: popNandPushInt(2,SqueakVM.quickDivide(stackInteger(1),stackInteger(0)));  // Integer.divide /  (fails unless exact exact)
-                         break;
-                case 11: return false; //popNandPushIntIfOK(2,doMod(stackInteger(1),stackInteger(0)));  // Integer.mod \\
-                case 12: popNandPushInt(2,SqueakVM.div(stackInteger(1),stackInteger(0)));  // Integer.div //
-                         break;
-                case 13: popNandPushInt(2,doQuo(stackInteger(1),stackInteger(0)));  // Integer.quo
-                         break;
-                case 14: popNandPush(2,primitiveBitAnd());  // SmallInt.bitAnd
-                         break;
-                case 15: popNandPush(2,primitiveBitOr());  // SmallInt.bitOr
-                         break;
-                case 16: popNandPush(2,primitiveBitXor());  // SmallInt.bitXor
-                         break;
-                case 17: popNandPush(2,primitiveBitShift());  // SmallInt.bitShift
-                         break;
-                case 18: return primitiveMakePoint();
-                case 40: popNandPush(1, primitiveAsFloat() );
-                         break;
-                case 41: popNandPushFloat(2,stackFloat(1)+stackFloat(0));  // Float +        // +
-                         break;
-                case 42: popNandPushFloat(2,stackFloat(1)-stackFloat(0));  // Float -
-                         break;
-                case 43: return pop2andDoBool(stackFloat(1)<stackFloat(0));  // Float <
-                case 44: return pop2andDoBool(stackFloat(1)>stackFloat(0));  // Float >
-                case 45: return pop2andDoBool(stackFloat(1)<=stackFloat(0));  // Float <=
-                case 46: return pop2andDoBool(stackFloat(1)>=stackFloat(0));  // Float >=
-                case 47: return pop2andDoBool(stackFloat(1)==stackFloat(0));  // Float =
-                case 48: return pop2andDoBool(stackFloat(1)!=stackFloat(0));  // Float !=
-                case 49: popNandPushFloat(2,stackFloat(1)*stackFloat(0));  // Float.mul
-                         break;
-                case 50: popNandPushFloat(2,safeFDiv(stackFloat(1),stackFloat(0)));  // Float.div
-                         break;
-                case 51: popNandPush( 1, primitiveTruncate() );
-                         break;
-                case 58: popNandPushFloat(1,StrictMath.log(stackFloat(0)));  // Float.ln
-                         break;
-                case 60: popNandPush(2,primitiveAt(false,false,false)); // basicAt:
-                         break;
-                case 61: popNandPush(3,primitiveAtPut(false,false,false)); // basicAt:put:
-                         break;
-                case 62: popNandPush(1,primitiveSize()); // size
-                         break;
-                case 63: popNandPush(2,primitiveAt(false,true,false)); // basicAt:
-                         break;
-                case 64: popNandPush(3,primitiveAtPut(false,true,false)); // basicAt:put:
-                         break;
-                case 68: popNandPush(2,primitiveAt(false,false,true)); // Method.objectAt:
-                         break;
-                case 69: popNandPush(3,primitiveAtPut(false,false,true)); // Method.objectAt:put:
-                         break;
-                case 70: popNandPush(1,vm.instantiateClass( stackNonInteger( 0 ), 0 ) ); // Class.new
-                         break;
-                case 71: popNandPush(2,primitiveNewWithSize()); // Class.new
-                         break;
-                case 72: popNandPush(2,primitiveArrayBecome(false));
-                         break;
-                case 73: popNandPush(2,primitiveAt(false,false,true)); // instVarAt:
-                         break;
-                case 74: popNandPush(3,primitiveAtPut(false,false,true)); // instVarAt:put:
-                         break;
-                case 75: popNandPush(1,primitiveHash()); // Class.identityHash
-                         break;
-                case 77: popNandPush(1,primitiveSomeInstance(stackNonInteger(0))); // Class.someInstance
-                         break;
-                case 78: popNandPush(1,primitiveNextInstance(stackNonInteger(0))); // Class.someInstance
-                         break;
-                case 79: popNandPush(3,primitiveNewMethod()); // Compiledmethod.new
-                         break;
-                case 80: popNandPush(2,primitiveBlockCopy()); // Context.blockCopy:
-                         break;
-                case 81: primitiveBlockValue(argCount); // BlockContext.value
-                         break;
-                case 83: return vm.primitivePerform(argCount); // rcvr.perform:(with:)*
-                case 84: return vm.primitivePerformWithArgs(vm.getClass(vm.stackValue(2))); // rcvr.perform:withArguments:
-                case 85: semaphoreSignal(); // Semaphore.wait
-                         break;
-                case 86: semaphoreWait(); // Semaphore.wait
-                         break;
-                case 87: processResume(); // Process.resume
-                         break;
-                case 88: processSuspend(); // Process.suspend
-                         break;
-                case 89: return vm.clearMethodCache();  // selective
-                case 90: popNandPush(1,primitiveMousePoint()); // mousePoint
-                         break;
-                case 96: if (argCount==0) 
-                             primitiveCopyBits((SqueakObject)vm.top(),0);
-                         else 
-                             primitiveCopyBits((SqueakObject)vm.stackValue(1),1);
-                         break;
-                case 97: primitiveSnapshot();
-                         break;
-                case 100: return vm.primitivePerformInSuperclass((SqueakObject)vm.top()); // rcvr.perform:withArguments:InSuperclass
-                case 101: beCursor(argCount); // Cursor.beCursor
-                          break;
-                case 102: beDisplay((SqueakObject)vm.top()); // DisplayScreen.beDisplay
-                          break;
-                case 105: popNandPush(5,primitiveStringReplace()); // string and array replace
-                          break;
-                case 106: popNandPush(1,makePointWithXandY(SqueakVM.smallFromInt(640),SqueakVM.smallFromInt(480))); // actualScreenSize // FIXME: Use real size
-                          break;
-                case 107: popNandPush(1,primitiveMouseButtons()); // Sensor mouseButtons
-                          break;
-                case 108: popNandPush(1,primitiveKbdNext()); // Sensor kbdNext
-                          break;
-                case 109: popNandPush(1,primitiveKbdPeek()); // Sensor kbdPeek
-                          break;
-                case 110: popNandPush(2,(vm.stackValue(1) == vm.stackValue(0))? vm.trueObj : vm.falseObj); // ==
-                          break;
-                case 112: popNandPush(1,SqueakVM.smallFromInt(image.spaceLeft())); // bytesLeft
-                          break;
-                case 113: System.exit(0);
-                case 116: return vm.flushMethodCacheForMethod((SqueakObject)vm.top());
-                case 119: return vm.flushMethodCacheForSelector((SqueakObject)vm.top());
-                case 121: popNandPush(1, primitiveImageFileName( argCount  ) );
-                          break;
-                case 122: BWMask= ~BWMask;
-                          break;
-                case 124: popNandPush(2,registerSemaphore(Squeak.splOb_TheLowSpaceSemaphore));
-                          break;
-                case 125: popNandPush(2,setLowSpaceThreshold());
-                          break;
-                case 128: popNandPush(2,primitiveArrayBecome(true));
-                          break;
-                case 129: popNandPush(1,image.specialObjectsArray);
-                          break;
-                case 130: popNandPush(1,SqueakVM.smallFromInt(image.fullGC())); // GC
-                          break;
-                case 131: popNandPush(1,SqueakVM.smallFromInt(image.partialGC())); // GCmost
-                          break;
-                case 134: popNandPush(2,registerSemaphore(Squeak.splOb_TheInterruptSemaphore));
-                          break;
-                case 135: popNandPush(1,millisecondClockValue());
-                          break;
-                case 136: popNandPush(3,primitiveSignalAtMilliseconds()); //Delay signal:atMs:());
-                          break;
-                case 137: popNandPush(1,primSeconds()); //Seconds since Jan 1, 1901
-                          break;
-                case 138: popNandPush(1,primitiveSomeObject()); // Class.someInstance
-                          break;
-                case 139: popNandPush(1,primitiveNextObject(stackNonInteger(0))); // Class.someInstance
-                          break;
-                case 142: popNandPush(1, primitiveVmPath() );
-                          break;
-                case 148: popNandPush(1,((SqueakObject)vm.top()).cloneIn(image)); //imageName
-                          break;
-                case 149: popNandPush(2,vm.nilObj); //getAttribute
-                          break;
-                          
+                case 1:
+                    popNandPushInt(2, stackInteger(1) + stackInteger(0));  // Integer.add
+                    break;
+                case 2:
+                    popNandPushInt(2, stackInteger(1) - stackInteger(0));  // Integer.subtract
+                    break;
+                case 3:
+                    return pop2andDoBool(stackInteger(1) < stackInteger(0));  // Integer.less
+                case 4:
+                    return pop2andDoBool(stackInteger(1) > stackInteger(0));  // Integer.greater
+                case 5:
+                    return pop2andDoBool(stackInteger(1) <= stackInteger(0));  // Integer.leq
+                case 6:
+                    return pop2andDoBool(stackInteger(1) >= stackInteger(0));  // Integer.geq
+                case 7:
+                    return pop2andDoBool(stackInteger(1) == stackInteger(0));  // Integer.equal
+                case 8:
+                    return pop2andDoBool(stackInteger(1) != stackInteger(0));  // Integer.notequal
+                case 9:
+                    popNandPushInt(2, SqueakVM.safeMultiply(stackInteger(1), stackInteger(0)));  // Integer.multiply *
+                    break;
+                case 10:
+                    popNandPushInt(2, SqueakVM.quickDivide(stackInteger(1), stackInteger(0)));  // Integer.divide /  (fails unless exact exact)
+                    break;
+                case 11:
+                    return false; //popNandPushIntIfOK(2,doMod(stackInteger(1),stackInteger(0)));  // Integer.mod \\
+                case 12:
+                    popNandPushInt(2, SqueakVM.div(stackInteger(1), stackInteger(0)));  // Integer.div //
+                    break;
+                case 13:
+                    popNandPushInt(2, doQuo(stackInteger(1), stackInteger(0)));  // Integer.quo
+                    break;
+                case 14:
+                    popNandPush(2, primitiveBitAnd());  // SmallInt.bitAnd
+                    break;
+                case 15:
+                    popNandPush(2, primitiveBitOr());  // SmallInt.bitOr
+                    break;
+                case 16:
+                    popNandPush(2, primitiveBitXor());  // SmallInt.bitXor
+                    break;
+                case 17:
+                    popNandPush(2, primitiveBitShift());  // SmallInt.bitShift
+                    break;
+                case 18:
+                    return primitiveMakePoint();
+                case 40:
+                    popNandPush(1, primitiveAsFloat());
+                    break;
+                case 41:
+                    popNandPushFloat(2, stackFloat(1) + stackFloat(0));  // Float +        // +
+                    break;
+                case 42:
+                    popNandPushFloat(2, stackFloat(1) - stackFloat(0));  // Float -
+                    break;
+                case 43:
+                    return pop2andDoBool(stackFloat(1) < stackFloat(0));  // Float <
+                case 44:
+                    return pop2andDoBool(stackFloat(1) > stackFloat(0));  // Float >
+                case 45:
+                    return pop2andDoBool(stackFloat(1) <= stackFloat(0));  // Float <=
+                case 46:
+                    return pop2andDoBool(stackFloat(1) >= stackFloat(0));  // Float >=
+                case 47:
+                    return pop2andDoBool(stackFloat(1) == stackFloat(0));  // Float =
+                case 48:
+                    return pop2andDoBool(stackFloat(1) != stackFloat(0));  // Float !=
+                case 49:
+                    popNandPushFloat(2, stackFloat(1) * stackFloat(0));  // Float.mul
+                    break;
+                case 50:
+                    popNandPushFloat(2, safeFDiv(stackFloat(1), stackFloat(0)));  // Float.div
+                    break;
+                case 51:
+                    popNandPush(1, primitiveTruncate());
+                    break;
+                case 58:
+                    popNandPushFloat(1, StrictMath.log(stackFloat(0)));  // Float.ln
+                    break;
+                case 60:
+                    popNandPush(2, primitiveAt(false, false, false)); // basicAt:
+                    break;
+                case 61:
+                    popNandPush(3, primitiveAtPut(false, false, false)); // basicAt:put:
+                    break;
+                case 62:
+                    popNandPush(1, primitiveSize()); // size
+                    break;
+                case 63:
+                    popNandPush(2, primitiveAt(false, true, false)); // basicAt:
+                    break;
+                case 64:
+                    popNandPush(3, primitiveAtPut(false, true, false)); // basicAt:put:
+                    break;
+                case 68:
+                    popNandPush(2, primitiveAt(false, false, true)); // Method.objectAt:
+                    break;
+                case 69:
+                    popNandPush(3, primitiveAtPut(false, false, true)); // Method.objectAt:put:
+                    break;
+                case 70:
+                    popNandPush(1, vm.instantiateClass(stackNonInteger(0), 0)); // Class.new
+                    break;
+                case 71:
+                    popNandPush(2, primitiveNewWithSize()); // Class.new
+                    break;
+                case 72:
+                    popNandPush(2, primitiveArrayBecome(false));
+                    break;
+                case 73:
+                    popNandPush(2, primitiveAt(false, false, true)); // instVarAt:
+                    break;
+                case 74:
+                    popNandPush(3, primitiveAtPut(false, false, true)); // instVarAt:put:
+                    break;
+                case 75:
+                    popNandPush(1, primitiveHash()); // Class.identityHash
+                    break;
+                case 77:
+                    popNandPush(1, primitiveSomeInstance(stackNonInteger(0))); // Class.someInstance
+                    break;
+                case 78:
+                    popNandPush(1, primitiveNextInstance(stackNonInteger(0))); // Class.someInstance
+                    break;
+                case 79:
+                    popNandPush(3, primitiveNewMethod()); // Compiledmethod.new
+                    break;
+                case 80:
+                    popNandPush(2, primitiveBlockCopy()); // Context.blockCopy:
+                    break;
+                case 81:
+                    primitiveBlockValue(argCount); // BlockContext.value
+                    break;
+                case 83:
+                    return vm.primitivePerform(argCount); // rcvr.perform:(with:)*
+                case 84:
+                    return vm.primitivePerformWithArgs(vm.getClass(vm.stackValue(2))); // rcvr.perform:withArguments:
+                case 85:
+                    semaphoreSignal(); // Semaphore.wait
+                    break;
+                case 86:
+                    semaphoreWait(); // Semaphore.wait
+                    break;
+                case 87:
+                    processResume(); // Process.resume
+                    break;
+                case 88:
+                    processSuspend(); // Process.suspend
+                    break;
+                case 89:
+                    return vm.clearMethodCache();  // selective
+                case 90:
+                    popNandPush(1, primitiveMousePoint()); // mousePoint
+                    break;
+                case 96:
+                    if (argCount == 0)
+                        primitiveCopyBits((SqueakObject) vm.top(), 0);
+                    else
+                        primitiveCopyBits((SqueakObject) vm.stackValue(1), 1);
+                    break;
+                case 97:
+                    primitiveSnapshot();
+                    break;
+                case 100:
+                    return vm.primitivePerformInSuperclass((SqueakObject) vm.top()); // rcvr.perform:withArguments:InSuperclass
+                case 101:
+                    beCursor(argCount); // Cursor.beCursor
+                    break;
+                case 102:
+                    beDisplay((SqueakObject) vm.top()); // DisplayScreen.beDisplay
+                    break;
+                case 105:
+                    popNandPush(5, primitiveStringReplace()); // string and array replace
+                    break;
+                case 106:
+                    popNandPush(1, makePointWithXandY(SqueakVM.smallFromInt(640), SqueakVM.smallFromInt(480))); // actualScreenSize // FIXME: Use real size
+                    break;
+                case 107:
+                    popNandPush(1, primitiveMouseButtons()); // Sensor mouseButtons
+                    break;
+                case 108:
+                    popNandPush(1, primitiveKbdNext()); // Sensor kbdNext
+                    break;
+                case 109:
+                    popNandPush(1, primitiveKbdPeek()); // Sensor kbdPeek
+                    break;
+                case 110:
+                    popNandPush(2, (vm.stackValue(1) == vm.stackValue(0)) ? vm.trueObj : vm.falseObj); // ==
+                    break;
+                case 112:
+                    popNandPush(1, SqueakVM.smallFromInt(image.spaceLeft())); // bytesLeft
+                    break;
+                case 113:
+                    System.exit(0);
+                case 116:
+                    return vm.flushMethodCacheForMethod((SqueakObject) vm.top());
+                case 119:
+                    return vm.flushMethodCacheForSelector((SqueakObject) vm.top());
+                case 121:
+                    popNandPush(1, primitiveImageFileName(argCount));
+                    break;
+                case 122:
+                    BWMask = ~BWMask;
+                    break;
+                case 124:
+                    popNandPush(2, registerSemaphore(Squeak.splOb_TheLowSpaceSemaphore));
+                    break;
+                case 125:
+                    popNandPush(2, setLowSpaceThreshold());
+                    break;
+                case 128:
+                    popNandPush(2, primitiveArrayBecome(true));
+                    break;
+                case 129:
+                    popNandPush(1, image.specialObjectsArray);
+                    break;
+                case 130:
+                    popNandPush(1, SqueakVM.smallFromInt(image.fullGC())); // GC
+                    break;
+                case 131:
+                    popNandPush(1, SqueakVM.smallFromInt(image.partialGC())); // GCmost
+                    break;
+                case 134:
+                    popNandPush(2, registerSemaphore(Squeak.splOb_TheInterruptSemaphore));
+                    break;
+                case 135:
+                    popNandPush(1, millisecondClockValue());
+                    break;
+                case 136:
+                    popNandPush(3, primitiveSignalAtMilliseconds()); //Delay signal:atMs:());
+                    break;
+                case 137:
+                    popNandPush(1, primSeconds()); //Seconds since Jan 1, 1901
+                    break;
+                case 138:
+                    popNandPush(1, primitiveSomeObject()); // Class.someInstance
+                    break;
+                case 139:
+                    popNandPush(1, primitiveNextObject(stackNonInteger(0))); // Class.someInstance
+                    break;
+                case 142:
+                    popNandPush(1, primitiveVmPath());
+                    break;
+                case 148:
+                    popNandPush(1, ((SqueakObject) vm.top()).cloneIn(image)); //imageName
+                    break;
+                case 149:
+                    popNandPush(2, vm.nilObj); //getAttribute
+                    break;
+
                 // File System primitives
-                case 150: popNandPush( 2, fileSystemPrimitives.fileAtEnd( argCount ) );
-                          break;
-                case 151: popNandPush( 2, fileSystemPrimitives.fileClose( argCount ) );
-                          break;
-                case 152: popNandPush( 2, fileSystemPrimitives.getPosition( argCount ) );
-                          break;
-                case 153: popNandPush( 3, fileSystemPrimitives.openWritable( argCount ) );
-                          break;
-                case 154: popNandPush( 5, fileSystemPrimitives.readIntoStartingAtCount( argCount ) );
-                          break;
-                case 155: popNandPush( 3, fileSystemPrimitives.fileSetPosition( argCount ) );
-                          break;
-                case 156: popNandPush( 2, fileSystemPrimitives.fileDelete( argCount ) );
-                          break;
-                case 157: popNandPush( 2, fileSystemPrimitives.fileSize( argCount ) );
-                          break;
-                case 158: popNandPush( 5, fileSystemPrimitives.fileWrite( argCount ) );
-                          break;
-                case 159: popNandPush( 3, fileSystemPrimitives.fileRename( argCount ) );
-                          break;
-                case 160: popNandPush( 2, fileSystemPrimitives.directoryCreate( argCount ) );
-                          break;
-                case 161: popNandPush( 1, fileSystemPrimitives.directoryDelimitor()); //path delimiter
-                          break;
-                case 162: popNandPush( 3, fileSystemPrimitives.lookupEntryInIndex( argCount ) ); //path delimiter
-                          break;
-                          
-                case 230: primitiveYield(argCount); //yield for 10ms
-                          break;
-                default: return false; 
+                case 150:
+                    popNandPush(2, fileSystemPrimitives.fileAtEnd(argCount));
+                    break;
+                case 151:
+                    popNandPush(2, fileSystemPrimitives.fileClose(argCount));
+                    break;
+                case 152:
+                    popNandPush(2, fileSystemPrimitives.getPosition(argCount));
+                    break;
+                case 153:
+                    popNandPush(3, fileSystemPrimitives.openWritable(argCount));
+                    break;
+                case 154:
+                    popNandPush(5, fileSystemPrimitives.readIntoStartingAtCount(argCount));
+                    break;
+                case 155:
+                    popNandPush(3, fileSystemPrimitives.fileSetPosition(argCount));
+                    break;
+                case 156:
+                    popNandPush(2, fileSystemPrimitives.fileDelete(argCount));
+                    break;
+                case 157:
+                    popNandPush(2, fileSystemPrimitives.fileSize(argCount));
+                    break;
+                case 158:
+                    popNandPush(5, fileSystemPrimitives.fileWrite(argCount));
+                    break;
+                case 159:
+                    popNandPush(3, fileSystemPrimitives.fileRename(argCount));
+                    break;
+                case 160:
+                    popNandPush(2, fileSystemPrimitives.directoryCreate(argCount));
+                    break;
+                case 161:
+                    popNandPush(1, fileSystemPrimitives.directoryDelimitor()); //path delimiter
+                    break;
+                case 162:
+                    popNandPush(3, fileSystemPrimitives.lookupEntryInIndex(argCount)); //path delimiter
+                    break;
+
+                case 230:
+                    primitiveYield(argCount); //yield for 10ms
+                    break;
+                default:
+                    return false;
             }
             return true;
-        }
-        catch ( PrimitiveFailedException exception )
-        {
+        } catch (PrimitiveFailedException exception) {
             return false;
         }
     }
 
     /**
      * snapshotPrimitive
-     *    "Primitive. Write the current state of the object memory on a file in the
-     *    same format as the Smalltalk-80 release. The file can later be resumed,
-     *    returning you to this exact state. Return normally after writing the file.
-     *    Essential. See Object documentation whatIsAPrimitive."
-     *    
-     *    <primitive: 97>
-     *     ^nil "indicates error writing image file"
+     * "Primitive. Write the current state of the object memory on a file in the
+     * same format as the Smalltalk-80 release. The file can later be resumed,
+     * returning you to this exact state. Return normally after writing the file.
+     * Essential. See Object documentation whatIsAPrimitive."
+     * <p>
+     * <primitive: 97>
+     * ^nil "indicates error writing image file"
      */
-    private void primitiveSnapshot()
-    {
-        System.out.println( "Saving the image" );
-        try 
-        {
-            vm.image.save( new File( "/tmp/image.gz" ) );
-        }
-        catch ( IOException e ) 
-        {
+    private void primitiveSnapshot() {
+        System.out.println("Saving the image");
+        try {
+            vm.image.save(new File("/tmp/image.gz"));
+        } catch (IOException e) {
             e.printStackTrace();
             throw PrimitiveFailed;
         }
     }
-    
+
     /**
      * Primitive 121
      * "When called with a single string argument, record the string
@@ -483,13 +569,12 @@ class SqueakPrimitiveHandler
      * arguments, return a string containing the current image file
      * name."
      */
-    private Object primitiveImageFileName( int argCount ) 
-    {
-        if ( argCount == 0 )
-            return makeStString( vm.image.imageFile().getAbsolutePath() );
-        
-        if ( argCount == 1 )
-            new Exception( "Cannot set the image name yet, argument is '" + stackNonInteger( 0 ) + "'" ).printStackTrace();
+    private Object primitiveImageFileName(int argCount) {
+        if (argCount == 0)
+            return makeStString(vm.image.imageFile().getAbsolutePath());
+
+        if (argCount == 1)
+            new Exception("Cannot set the image name yet, argument is '" + stackNonInteger(0) + "'").printStackTrace();
 
         throw PrimitiveFailed;
     }
@@ -497,92 +582,83 @@ class SqueakPrimitiveHandler
     /**
      * SystemDictionary>>vmPath.
      * Primitive 142.
-     * 
+     * <p>
      * primVmPath
-     *   "Answer the path for the directory containing the Smalltalk virtual machine. 
-     *   Return the empty string if this primitive is not implemented."
-     *        "Smalltalk vmPath"
-     *
-     *   <primitive: 142>
-     *   ^ ''
+     * "Answer the path for the directory containing the Smalltalk virtual machine.
+     * Return the empty string if this primitive is not implemented."
+     * "Smalltalk vmPath"
+     * <p>
+     * <primitive: 142>
+     * ^ ''
      */
-    private SqueakObject primitiveVmPath()
-    {
-        return makeStString( System.getProperty( "user.dir" ) );
+    private SqueakObject primitiveVmPath() {
+        return makeStString(System.getProperty("user.dir"));
     }
 
-    private boolean pop2andDoBool(boolean bool) 
-    {
-        vm.success= true; // FIXME: Why have a side effect here? 
-        return vm.pushBoolAndPeek(bool); 
+    private boolean pop2andDoBool(boolean bool) {
+        vm.success = true; // FIXME: Why have a side effect here?
+        return vm.pushBoolAndPeek(bool);
     }
-    
-    
-    private void popNandPush(int nToPop, Object returnValue) 
-    {
-        if ( returnValue == null )
-            new Exception( "NULL in popNandPush()" ).printStackTrace(); // FIXME: Did I break this by not checking for a null return value?
-        
-        vm.popNandPush(nToPop,returnValue);
+
+
+    private void popNandPush(int nToPop, Object returnValue) {
+        if (returnValue == null)
+            new Exception("NULL in popNandPush()").printStackTrace(); // FIXME: Did I break this by not checking for a null return value?
+
+        vm.popNandPush(nToPop, returnValue);
     }
-    
-    private void popNandPushInt(int nToPop, int returnValue) 
-    {
+
+    private void popNandPushInt(int nToPop, int returnValue) {
         Integer value = SqueakVM.smallFromInt(returnValue);
-        if ( value == null )
+        if (value == null)
             throw PrimitiveFailed;
-        
-        popNandPush(nToPop, value); 
+
+        popNandPush(nToPop, value);
     }
-    
-    private void popNandPushFloat(int nToPop, double returnValue) 
-    {
-        
-        popNandPush( nToPop, makeFloat( returnValue ) ); 
+
+    private void popNandPushFloat(int nToPop, double returnValue) {
+
+        popNandPush(nToPop, makeFloat(returnValue));
     }
-    
-    int stackInteger(int nDeep) 
-    {
-        return checkSmallInt(vm.stackValue(nDeep)); 
+
+    int stackInteger(int nDeep) {
+        return checkSmallInt(vm.stackValue(nDeep));
     }
-    
+
     /**
      * If maybeSmall is a small integer, return its value, fail otherwise.
      */
-    private int checkSmallInt(Object maybeSmall)
-    {
+    private int checkSmallInt(Object maybeSmall) {
         if (SqueakVM.isSmallInt(maybeSmall))
-			return SqueakVM.intFromSmall(((Integer)maybeSmall));
-        
+            return SqueakVM.intFromSmall(((Integer) maybeSmall));
+
         throw PrimitiveFailed;
     }
-    
-    private double stackFloat(int nDeep) 
-    {
-        return checkFloat(vm.stackValue(nDeep)); 
+
+    private double stackFloat(int nDeep) {
+        return checkFloat(vm.stackValue(nDeep));
     }
-    
+
     /**
      * If maybeFloat is a Squeak Float return its value, fail otherwise
      */
-    private double checkFloat(Object maybeFloat) 
-    {
-        if (vm.getClass(maybeFloat)==vm.specialObjects[Squeak.splOb_ClassFloat])
-            return ((SqueakObject)maybeFloat).getFloatBits();
-        
+    private double checkFloat(Object maybeFloat) {
+        if (vm.getClass(maybeFloat) == vm.specialObjects[Squeak.splOb_ClassFloat])
+            return ((SqueakObject) maybeFloat).getFloatBits();
+
         throw PrimitiveFailed;
     }
-    
-    private double safeFDiv(double dividend, double divisor) 
-    {
+
+    private double safeFDiv(double dividend, double divisor) {
         if (divisor == 0.0d)
             throw PrimitiveFailed;
 
-        return dividend / divisor; 
+        return dividend / divisor;
     }
-    
+
     /**
      * Fail if maybeSmall is not a SmallInteger
+     *
      * @param maybeSmall
      * @return
      */
@@ -590,425 +666,382 @@ class SqueakPrimitiveHandler
     {
         if (SqueakVM.isSmallInt(maybeSmall))
             throw PrimitiveFailed;
-        
-        return (SqueakObject) maybeSmall; 
+
+        return (SqueakObject) maybeSmall;
     }
-    
-    int stackPos32BitValue(int nDeep) 
-    {
-        Object stackVal= vm.stackValue(nDeep);
-        if (SqueakVM.isSmallInt(stackVal)) 
-        {
-            int value= SqueakVM.intFromSmall(((Integer) stackVal));
+
+    int stackPos32BitValue(int nDeep) {
+        Object stackVal = vm.stackValue(nDeep);
+        if (SqueakVM.isSmallInt(stackVal)) {
+            int value = SqueakVM.intFromSmall(((Integer) stackVal));
             if (value >= 0)
                 return value;
-            
+
             throw PrimitiveFailed;
         }
-        
-        if (!isA(stackVal,Squeak.splOb_ClassLargePositiveInteger))
+
+        if (!isA(stackVal, Squeak.splOb_ClassLargePositiveInteger))
             throw PrimitiveFailed;
 
-        byte[] bytes= (byte[])((SqueakObject)stackVal).bits;
-        int value= 0;
-        for(int i=0; i<4; i++)
-            value= value + ((bytes[i]&255)<<(8*i));
-        return value; 
+        byte[] bytes = (byte[]) ((SqueakObject) stackVal).bits;
+        int value = 0;
+        for (int i = 0; i < 4; i++)
+            value = value + ((bytes[i] & 255) << (8 * i));
+        return value;
     }
 
-    Object pos32BitIntFor( long pos32Val )
-    {
-        if ( pos32Val < Integer.MIN_VALUE ||
-             pos32Val > Integer.MAX_VALUE )
-        {
-            new Exception( "long to int overflow" ).printStackTrace();
+    Object pos32BitIntFor(long pos32Val) {
+        if (pos32Val < Integer.MIN_VALUE ||
+                pos32Val > Integer.MAX_VALUE) {
+            new Exception("long to int overflow").printStackTrace();
             throw PrimitiveFailed;
         }
-        
-        return pos32BitIntFor( (int) pos32Val ); 
+
+        return pos32BitIntFor((int) pos32Val);
     }
-    
-    Object pos32BitIntFor(int pos32Val) 
-    {
+
+    Object pos32BitIntFor(int pos32Val) {
         // Return the 32-bit quantity as a positive 32-bit integer
-        if (pos32Val >= 0) 
-        {
-            Object smallInt= SqueakVM.smallFromInt(pos32Val);
-            if (smallInt != null) 
-                return smallInt; 
+        if (pos32Val >= 0) {
+            Object smallInt = SqueakVM.smallFromInt(pos32Val);
+            if (smallInt != null)
+                return smallInt;
         }
-        SqueakObject lgIntClass= (SqueakObject)vm.specialObjects[Squeak.splOb_ClassLargePositiveInteger];
-        SqueakObject lgIntObj= vm.instantiateClass(lgIntClass,4);
-        byte[] bytes= (byte[])lgIntObj.bits;
-        for(int i=0; i<4; i++)
-            bytes[i]= (byte) ((pos32Val>>>(8*i))&255);
-        return lgIntObj; 
-    }
-    
-    SqueakObject stackNonInteger(int nDeep) 
-    {
-        return checkNonSmallInt(vm.stackValue(nDeep)); 
+        SqueakObject lgIntClass = (SqueakObject) vm.specialObjects[Squeak.splOb_ClassLargePositiveInteger];
+        SqueakObject lgIntObj = vm.instantiateClass(lgIntClass, 4);
+        byte[] bytes = (byte[]) lgIntObj.bits;
+        for (int i = 0; i < 4; i++)
+            bytes[i] = (byte) ((pos32Val >>> (8 * i)) & 255);
+        return lgIntObj;
     }
 
-    SqueakObject squeakArray( Object[] javaArray )
-    {
-        SqueakObject array = vm.instantiateClass( Squeak.splOb_ClassArray, javaArray.length );
-        for ( int index = 0; index < javaArray.length; index++ )
-            array.setPointer( index, javaArray[index] );
+    SqueakObject stackNonInteger(int nDeep) {
+        return checkNonSmallInt(vm.stackValue(nDeep));
+    }
+
+    SqueakObject squeakArray(Object[] javaArray) {
+        SqueakObject array = vm.instantiateClass(Squeak.splOb_ClassArray, javaArray.length);
+        for (int index = 0; index < javaArray.length; index++)
+            array.setPointer(index, javaArray[index]);
 
         return array;
     }
 
-    Object squeakSeconds( long millis )
-    {
-        int secs = (int) ( millis / 1000 ); //milliseconds -> seconds
-        secs += ( 69 * 365 + 17 ) * 24 * 3600; //Adjust from 1901 to 1970
-        
+    Object squeakSeconds(long millis) {
+        int secs = (int) (millis / 1000); //milliseconds -> seconds
+        secs += (69 * 365 + 17) * 24 * 3600; //Adjust from 1901 to 1970
+
         return pos32BitIntFor(secs);
     }
 
 
-    SqueakObject squeakNil()
-    {
+    SqueakObject squeakNil() {
         return vm.nilObj;
     }
-    
-    SqueakObject squeakBool( boolean bool ) 
-    {
-        return bool ? vm.trueObj : vm.falseObj; 
+
+    SqueakObject squeakBool(boolean bool) {
+        return bool ? vm.trueObj : vm.falseObj;
     }
-    
+
     /**
      * Note: this method does not check to see that the passed
-     *       object is an instance of Boolean.
-     *       
+     * object is an instance of Boolean.
+     *
      * @return true iff object is the special Squeak true object
      */
-    boolean javaBool( SqueakObject object )
-    {
-        return object == vm.trueObj; 
+    boolean javaBool(SqueakObject object) {
+        return object == vm.trueObj;
     }
-    
-    private SqueakObject primitiveAsFloat() 
-    {
+
+    private SqueakObject primitiveAsFloat() {
         int intValue = stackInteger(0);
 
         return makeFloat(intValue);
     }
 
-    private Object primitiveTruncate() 
-    {
-        double floatVal = stackFloat( 0 );
-        if ( !(-1073741824.0 <= floatVal) && (floatVal <= 1073741823.0)) 
+    private Object primitiveTruncate() {
+        double floatVal = stackFloat(0);
+        if (!(-1073741824.0 <= floatVal) && (floatVal <= 1073741823.0))
             throw PrimitiveFailed;
-        
-        return SqueakVM.smallFromInt( (new Double(floatVal)).intValue()); //**must be a better way  Probably Math.round()?
+
+        return SqueakVM.smallFromInt((new Double(floatVal)).intValue()); //**must be a better way  Probably Math.round()?
     }
-            
-    private SqueakObject makeFloat(double value) 
-    {
-        SqueakObject floatClass= (SqueakObject)vm.specialObjects[Squeak.splOb_ClassFloat];
-        SqueakObject newFloat= vm.instantiateClass(floatClass,-1);
+
+    private SqueakObject makeFloat(double value) {
+        SqueakObject floatClass = (SqueakObject) vm.specialObjects[Squeak.splOb_ClassFloat];
+        SqueakObject newFloat = vm.instantiateClass(floatClass, -1);
         newFloat.setFloatBits(value);
-        return newFloat; 
+        return newFloat;
     }
-    
-    boolean primitiveMakePoint() 
-    {
-        Object x= vm.stackValue(1);
-        Object y= vm.stackValue(0);
-        vm.popNandPush(2,makePointWithXandY(x,y)); 
-        return true; 
+
+    boolean primitiveMakePoint() {
+        Object x = vm.stackValue(1);
+        Object y = vm.stackValue(0);
+        vm.popNandPush(2, makePointWithXandY(x, y));
+        return true;
     }
-    
-    private SqueakObject makePointWithXandY(Object x, Object y) 
-    {
-        SqueakObject pointClass= (SqueakObject)vm.specialObjects[Squeak.splOb_ClassPoint];
-        SqueakObject newPoint= vm.instantiateClass(pointClass,0);
-        newPoint.setPointer(Squeak.Point_x,x);
-        newPoint.setPointer(Squeak.Point_y,y);
-        return newPoint; 
+
+    private SqueakObject makePointWithXandY(Object x, Object y) {
+        SqueakObject pointClass = (SqueakObject) vm.specialObjects[Squeak.splOb_ClassPoint];
+        SqueakObject newPoint = vm.instantiateClass(pointClass, 0);
+        newPoint.setPointer(Squeak.Point_x, x);
+        newPoint.setPointer(Squeak.Point_y, y);
+        return newPoint;
     }
-    
-    private SqueakObject primitiveNewWithSize() 
-    {
-        int size= stackPos32BitValue(0);
-        
-        return vm.instantiateClass(((SqueakObject)vm.stackValue(1)),size); 
+
+    private SqueakObject primitiveNewWithSize() {
+        int size = stackPos32BitValue(0);
+
+        return vm.instantiateClass(((SqueakObject) vm.stackValue(1)), size);
     }
-    
-    private SqueakObject primitiveNewMethod() 
-    {
-        Object headerInt= vm.top();
-        int byteCount= stackInteger(1);
-        int methodHeader= checkSmallInt(headerInt);
-        int litCount= (methodHeader>>9)&0xFF;
-        SqueakObject method= vm.instantiateClass(((SqueakObject)vm.stackValue(2)),byteCount);
-        Object[] pointers= new Object[litCount+1];
-        Arrays.fill(pointers,vm.nilObj);
-        pointers[0]= headerInt;
+
+    private SqueakObject primitiveNewMethod() {
+        Object headerInt = vm.top();
+        int byteCount = stackInteger(1);
+        int methodHeader = checkSmallInt(headerInt);
+        int litCount = (methodHeader >> 9) & 0xFF;
+        SqueakObject method = vm.instantiateClass(((SqueakObject) vm.stackValue(2)), byteCount);
+        Object[] pointers = new Object[litCount + 1];
+        Arrays.fill(pointers, vm.nilObj);
+        pointers[0] = headerInt;
         method.methodAddPointers(pointers);
-        return method; 
+        return method;
     }
-    
-    
+
+
     //String and Array Primitives
     // FIXME: makeStString() but squeakBool() ? Pick one!
-    SqueakObject makeStString(String javaString) 
-    {
-        byte[] byteString= javaString.getBytes();
-        SqueakObject stString= vm.instantiateClass((SqueakObject)vm.specialObjects[Squeak.splOb_ClassString],javaString.length());
-        System.arraycopy(byteString,0,stString.bits,0,byteString.length);
-        return stString; 
+    SqueakObject makeStString(String javaString) {
+        byte[] byteString = javaString.getBytes();
+        SqueakObject stString = vm.instantiateClass((SqueakObject) vm.specialObjects[Squeak.splOb_ClassString], javaString.length());
+        System.arraycopy(byteString, 0, stString.bits, 0, byteString.length);
+        return stString;
     }
 
     /**
-     * Returns size Integer (but may set success false) 
+     * Returns size Integer (but may set success false)
      */
-    private Object primitiveSize() 
-    {
+    private Object primitiveSize() {
         Object rcvr = vm.top();
         int size = indexableSize(rcvr);
         if (size == -1) //not indexable
             throw PrimitiveFailed;
-        
-        return pos32BitIntFor(size); 
+
+        return pos32BitIntFor(size);
     }
-    
-    private Object primitiveAt(boolean cameFromAtBytecode, boolean convertChars, boolean includeInstVars) 
-    {
+
+    private Object primitiveAt(boolean cameFromAtBytecode, boolean convertChars, boolean includeInstVars) {
         //Returns result of at: or sets success false
         SqueakObject array = stackNonInteger(1);
-        int index= stackPos32BitValue(0); //note non-int returns zero
+        int index = stackPos32BitValue(0); //note non-int returns zero
 
         AtCacheInfo info;
-        if (cameFromAtBytecode) 
-        {
+        if (cameFromAtBytecode) {
             // fast entry checks cache
-            info= atCache[array.hashCode() & atCacheMask];
+            info = atCache[array.hashCode() & atCacheMask];
             if (info.array != array)
                 throw PrimitiveFailed;
-        }
-        else  
-        {
+        } else {
             // slow entry installs in cache if appropriate
-            if (array.format==6 && isA(array,Squeak.splOb_ClassFloat)) 
-            {
+            if (array.format == 6 && isA(array, Squeak.splOb_ClassFloat)) {
                 // hack to make Float hash work
-                long floatBits= Double.doubleToRawLongBits(array.getFloatBits());
-                if (index==1) 
-                    return pos32BitIntFor((int)(floatBits>>>32));
-                if (index==2) 
-                    return pos32BitIntFor((int)(floatBits&0xFFFFFFFF));
-                
+                long floatBits = Double.doubleToRawLongBits(array.getFloatBits());
+                if (index == 1)
+                    return pos32BitIntFor((int) (floatBits >>> 32));
+                if (index == 2)
+                    return pos32BitIntFor((int) (floatBits & 0xFFFFFFFF));
+
                 throw PrimitiveFailed;
             }
-            info= makeCacheInfo(atCache, vm.specialSelectors[32], array, convertChars, includeInstVars); 
+            info = makeCacheInfo(atCache, vm.specialSelectors[32], array, convertChars, includeInstVars);
         }
-        if (index<1 || index>info.size)
+        if (index < 1 || index > info.size)
             throw PrimitiveFailed;
-        
+
         if (includeInstVars)  //pointers...   instVarAt and objectAt
-            return array.pointers[index-1];
-        if (array.format<6)   //pointers...   normal at:
-            return array.pointers[index-1+info.ivarOffset];
-        if (array.format<8)   // words... 
+            return array.pointers[index - 1];
+        if (array.format < 6)   //pointers...   normal at:
+            return array.pointers[index - 1 + info.ivarOffset];
+        if (array.format < 8)   // words...
         {
-            int value= ((int[])array.bits)[index-1];
+            int value = ((int[]) array.bits)[index - 1];
             return pos32BitIntFor(value);
         }
-        if (array.format<12)  // bytes... 
+        if (array.format < 12)  // bytes...
         {
-            int value= (((byte[])array.bits)[index-1]) & 0xFF;
-            if (info.convertChars) 
+            int value = (((byte[]) array.bits)[index - 1]) & 0xFF;
+            if (info.convertChars)
                 return charFromInt(value);
-			else
-				return SqueakVM.smallFromInt(value); 
+            else
+                return SqueakVM.smallFromInt(value);
         }
         // methods (format>=12) must simulate Squeak's method indexing
-        int offset= array.pointersSize()*4;
-        if (index-1-offset < 0) //reading lits as bytes
+        int offset = array.pointersSize() * 4;
+        if (index - 1 - offset < 0) //reading lits as bytes
             throw PrimitiveFailed;
-        
-        return SqueakVM.smallFromInt((((byte[])array.bits)[index-1-offset]) & 0xFF); 
+
+        return SqueakVM.smallFromInt((((byte[]) array.bits)[index - 1 - offset]) & 0xFF);
     }
-    
-    SqueakObject charFromInt(int ascii) 
-    {
-        SqueakObject charTable= (SqueakObject)vm.specialObjects[Squeak.splOb_CharacterTable];
-        return charTable.getPointerNI(ascii); 
+
+    SqueakObject charFromInt(int ascii) {
+        SqueakObject charTable = (SqueakObject) vm.specialObjects[Squeak.splOb_CharacterTable];
+        return charTable.getPointerNI(ascii);
     }
 
     /**
      * @return result of at:put:
      */
-    private Object primitiveAtPut(boolean cameFromAtBytecode, boolean convertChars, boolean includeInstVars) 
-    {
+    private Object primitiveAtPut(boolean cameFromAtBytecode, boolean convertChars, boolean includeInstVars) {
         SqueakObject array = stackNonInteger(2);
-        int index= stackPos32BitValue(1); //note non-int returns zero
+        int index = stackPos32BitValue(1); //note non-int returns zero
 
         AtCacheInfo info;
-        if (cameFromAtBytecode) 
-        {
+        if (cameFromAtBytecode) {
             // fast entry checks cache
-            info= atPutCache[array.hashCode() & atCacheMask];
+            info = atPutCache[array.hashCode() & atCacheMask];
             if (info.array != array)
                 throw PrimitiveFailed;
-        }
-        else
-        {
+        } else {
             // slow entry installs in cache if appropriate
-            info= makeCacheInfo(atPutCache, vm.specialSelectors[34], array, convertChars, includeInstVars); 
+            info = makeCacheInfo(atPutCache, vm.specialSelectors[34], array, convertChars, includeInstVars);
         }
-        if (index<1 || index>info.size)
+        if (index < 1 || index > info.size)
             throw PrimitiveFailed;
 
-        Object objToPut= vm.stackValue(0);
-        if (includeInstVars) 
-        {
+        Object objToPut = vm.stackValue(0);
+        if (includeInstVars) {
             // pointers...   instVarAtPut and objectAtPut
-            array.pointers[index-1]= objToPut; //eg, objectAt:
-            return objToPut; 
+            array.pointers[index - 1] = objToPut; //eg, objectAt:
+            return objToPut;
         }
-        if (array.format<6)
-        {
+        if (array.format < 6) {
             // pointers...   normal atPut
-            array.pointers[index-1+info.ivarOffset]= objToPut;
-            return objToPut; 
+            array.pointers[index - 1 + info.ivarOffset] = objToPut;
+            return objToPut;
         }
         int intToPut;
-        if (array.format<8)
-        {
+        if (array.format < 8) {
             // words...
-            intToPut= stackPos32BitValue(0);
+            intToPut = stackPos32BitValue(0);
 
-            ((int[])array.bits)[index-1]= intToPut;
-            return objToPut; 
+            ((int[]) array.bits)[index - 1] = intToPut;
+            return objToPut;
         }
         // bytes...
-        if (info.convertChars) 
-        {
+        if (info.convertChars) {
             // put a character...
             if (SqueakVM.isSmallInt(objToPut))
                 throw PrimitiveFailed;
 
-            SqueakObject sqObjToPut= (SqueakObject)objToPut;
+            SqueakObject sqObjToPut = (SqueakObject) objToPut;
             if ((sqObjToPut.sqClass != vm.specialObjects[Squeak.splOb_ClassCharacter]))
                 throw PrimitiveFailed;
 
-            Object asciiToPut= sqObjToPut.getPointer(0);
+            Object asciiToPut = sqObjToPut.getPointer(0);
             if (!(SqueakVM.isSmallInt(asciiToPut)))
                 throw PrimitiveFailed;
 
-            intToPut= SqueakVM.intFromSmall(((Integer)asciiToPut)); 
-        }
-        else 
-        {
+            intToPut = SqueakVM.intFromSmall(((Integer) asciiToPut));
+        } else {
             // put a byte...
             if (!(SqueakVM.isSmallInt(objToPut)))
                 throw PrimitiveFailed;
 
-            intToPut= SqueakVM.intFromSmall(((Integer)objToPut)); 
+            intToPut = SqueakVM.intFromSmall(((Integer) objToPut));
         }
-        if (intToPut<0 || intToPut>255)
+        if (intToPut < 0 || intToPut > 255)
             throw PrimitiveFailed;
 
-        if (array.format<8)
-        {
+        if (array.format < 8) {
             // bytes...
-            ((byte[])array.bits)[index-1]= (byte)intToPut;
-            return objToPut; 
+            ((byte[]) array.bits)[index - 1] = (byte) intToPut;
+            return objToPut;
         }
         // methods (format>=12) must simulate Squeak's method indexing
-        int offset= array.pointersSize()*4;
-        if (index-1-offset < 0)
+        int offset = array.pointersSize() * 4;
+        if (index - 1 - offset < 0)
             throw PrimitiveFailed;   //writing lits as bytes 
 
-        ((byte[])array.bits)[index-1-offset]= (byte)intToPut;
-        return objToPut; 
+        ((byte[]) array.bits)[index - 1 - offset] = (byte) intToPut;
+        return objToPut;
     }
-    
+
     // FIXME: is this the same as SqueakObject.instSize() ?
-    private int indexableSize(Object obj) 
-    {
-        if (SqueakVM.isSmallInt(obj)) 
+    private int indexableSize(Object obj) {
+        if (SqueakVM.isSmallInt(obj))
             return -1; // -1 means not indexable
-        SqueakObject sqObj= (SqueakObject) obj;
-        short fmt= sqObj.format;
-        if (fmt<2)
+        SqueakObject sqObj = (SqueakObject) obj;
+        short fmt = sqObj.format;
+        if (fmt < 2)
             return -1; //not indexable
-        if (fmt==3 && vm.isContext(sqObj)) 
+        if (fmt == 3 && vm.isContext(sqObj))
             return sqObj.getPointerI(Squeak.Context_stackPointer).intValue();
-        if (fmt<6) 
+        if (fmt < 6)
             return sqObj.pointersSize() - sqObj.instSize(); // pointers
-        if (fmt<12)
+        if (fmt < 12)
             return sqObj.bitsSize(); // words or bytes
-        return sqObj.bitsSize() + (4*sqObj.pointersSize());  // methods
+        return sqObj.bitsSize() + (4 * sqObj.pointersSize());  // methods
     }
-    
-    private SqueakObject primitiveStringReplace() 
-    {
-        SqueakObject dst= (SqueakObject)vm.stackValue(4);
-        int dstPos= stackInteger(3)-1;
-        int count= stackInteger(2) - dstPos;
+
+    private SqueakObject primitiveStringReplace() {
+        SqueakObject dst = (SqueakObject) vm.stackValue(4);
+        int dstPos = stackInteger(3) - 1;
+        int count = stackInteger(2) - dstPos;
         //  if (count<=0) {success= false; return dst; } //fail for compat, later succeed
-        SqueakObject src= (SqueakObject)vm.stackValue(1);
-        int srcPos= stackInteger(0)-1;
-        short srcFmt= src.format;
-        short dstFmt= dst.format;
+        SqueakObject src = (SqueakObject) vm.stackValue(1);
+        int srcPos = stackInteger(0) - 1;
+        short srcFmt = src.format;
+        short dstFmt = dst.format;
         if (dstFmt < 8)
             if (dstFmt != srcFmt) //incompatible formats
                 throw PrimitiveFailed;
-            else if ((dstFmt&0xC) != (srcFmt&0xC)) //incompatible formats
+            else if ((dstFmt & 0xC) != (srcFmt & 0xC)) //incompatible formats
                 throw PrimitiveFailed;
-        if (srcFmt<4) 
-        {
+        if (srcFmt < 4) {
             //pointer type objects
-            int totalLength= src.pointersSize();
-            int srcInstSize= src.instSize();
-            srcPos+= srcInstSize;
+            int totalLength = src.pointersSize();
+            int srcInstSize = src.instSize();
+            srcPos += srcInstSize;
             if ((srcPos < 0) || (srcPos + count) > totalLength)  //would go out of bounds
                 throw PrimitiveFailed;
-            
-            totalLength= dst.pointersSize();
-            int dstInstSize= dst.instSize();
-            dstPos+= dstInstSize;
+
+            totalLength = dst.pointersSize();
+            int dstInstSize = dst.instSize();
+            dstPos += dstInstSize;
             if ((dstPos < 0) || (dstPos + count) > totalLength)  //would go out of bounds
                 throw PrimitiveFailed;
-            
+
             System.arraycopy(src.pointers, srcPos, dst.pointers, dstPos, count);
-            return dst; 
-        }
-        else 
-        {
+            return dst;
+        } else {
             //bits type objects
-            int totalLength= src.bitsSize();
+            int totalLength = src.bitsSize();
             if ((srcPos < 0) || (srcPos + count) > totalLength)  //would go out of bounds
                 throw PrimitiveFailed;
-            totalLength= dst.bitsSize();
+            totalLength = dst.bitsSize();
             if ((dstPos < 0) || (dstPos + count) > totalLength)  //would go out of bounds
                 throw PrimitiveFailed;
             System.arraycopy(src.bits, srcPos, dst.bits, dstPos, count);
-            return dst; 
+            return dst;
         }
     }
-        
+
     private boolean primitiveNext()  //Not yet implemented... 
     {
         // PrimitiveNext should succeed only if the stream's array is in the atCache.
         // Otherwise failure will lead to proper message lookup of at: and
         // subsequent installation in the cache if appropriate."
-        SqueakObject stream= stackNonInteger(0);
-        Object[] streamBody= stream.pointers;
-        if (streamBody == null || streamBody.length < (Squeak.Stream_limit+1))
+        SqueakObject stream = stackNonInteger(0);
+        Object[] streamBody = stream.pointers;
+        if (streamBody == null || streamBody.length < (Squeak.Stream_limit + 1))
             return false;
-        Object array= streamBody[Squeak.Stream_array];
-        if (SqueakVM.isSmallInt(array)) 
+        Object array = streamBody[Squeak.Stream_array];
+        if (SqueakVM.isSmallInt(array))
             return false;
-        int index= checkSmallInt(streamBody[Squeak.Stream_position]);
-        int limit= checkSmallInt(streamBody[Squeak.Stream_limit]);
-        int arraySize= indexableSize(array);
-        if (index >= limit) 
+        int index = checkSmallInt(streamBody[Squeak.Stream_position]);
+        int limit = checkSmallInt(streamBody[Squeak.Stream_limit]);
+        int arraySize = indexableSize(array);
+        if (index >= limit)
             return false;
         //  (index < limit and: [(atCache at: atIx+AtCacheOop) = array])
         //      ifFalse: [^ self primitiveFail].
@@ -1021,543 +1054,469 @@ class SqueakPrimitiveHandler
         //      [stream _ self stackTop.
         //      self storeInteger: StreamIndexIndex ofObject: stream withValue: index.
         //      ^ self pop: 1 thenPush: result].
-        return false; 
+        return false;
     }
-    
-    private SqueakObject primitiveBlockCopy() 
-    {
-        Object rcvr= vm.stackValue(1);
+
+    private SqueakObject primitiveBlockCopy() {
+        Object rcvr = vm.stackValue(1);
         if (SqueakVM.isSmallInt(rcvr))
             throw PrimitiveFailed;
 
-        Object sqArgCount= vm.top();
+        Object sqArgCount = vm.top();
         if (!(SqueakVM.isSmallInt(sqArgCount)))
             throw PrimitiveFailed;
-        
-        SqueakObject homeCtxt= (SqueakObject) rcvr;
+
+        SqueakObject homeCtxt = (SqueakObject) rcvr;
         if (!vm.isContext(homeCtxt))
             throw PrimitiveFailed;
-        
-        if (SqueakVM.isSmallInt(homeCtxt.getPointer(Squeak.Context_method)))
-        {
+
+        if (SqueakVM.isSmallInt(homeCtxt.getPointer(Squeak.Context_method))) {
             // ctxt is itself a block; get the context for its enclosing method
-            homeCtxt= homeCtxt.getPointerNI(Squeak.BlockContext_home);
+            homeCtxt = homeCtxt.getPointerNI(Squeak.BlockContext_home);
         }
-        int blockSize= homeCtxt.pointersSize() - homeCtxt.instSize(); //can use a const for instSize
-        SqueakObject newBlock= vm.instantiateClass(((SqueakObject)vm.specialObjects[Squeak.splOb_ClassBlockContext]),blockSize);
-        Integer initialPC= vm.encodeSqueakPC(vm.pc+2,vm.method); //*** check this...
-        newBlock.setPointer(Squeak.BlockContext_initialIP,initialPC);
-        newBlock.setPointer(Squeak.Context_instructionPointer,initialPC);// claim not needed; value will set it
-        newBlock.setPointer(Squeak.Context_stackPointer,SqueakVM.smallFromInt(0));
-        newBlock.setPointer(Squeak.BlockContext_argumentCount,sqArgCount);
-        newBlock.setPointer(Squeak.BlockContext_home,homeCtxt);
-        newBlock.setPointer(Squeak.Context_sender,vm.nilObj);
-        return newBlock; 
+        int blockSize = homeCtxt.pointersSize() - homeCtxt.instSize(); //can use a const for instSize
+        SqueakObject newBlock = vm.instantiateClass(((SqueakObject) vm.specialObjects[Squeak.splOb_ClassBlockContext]), blockSize);
+        Integer initialPC = vm.encodeSqueakPC(vm.pc + 2, vm.method); //*** check this...
+        newBlock.setPointer(Squeak.BlockContext_initialIP, initialPC);
+        newBlock.setPointer(Squeak.Context_instructionPointer, initialPC);// claim not needed; value will set it
+        newBlock.setPointer(Squeak.Context_stackPointer, SqueakVM.smallFromInt(0));
+        newBlock.setPointer(Squeak.BlockContext_argumentCount, sqArgCount);
+        newBlock.setPointer(Squeak.BlockContext_home, homeCtxt);
+        newBlock.setPointer(Squeak.Context_sender, vm.nilObj);
+        return newBlock;
     }
-    
-    private void primitiveBlockValue(int argCount) 
-    {
-        Object rcvr= vm.stackValue(argCount);
-        if (!isA(rcvr,Squeak.splOb_ClassBlockContext))
+
+    private void primitiveBlockValue(int argCount) {
+        Object rcvr = vm.stackValue(argCount);
+        if (!isA(rcvr, Squeak.splOb_ClassBlockContext))
             throw PrimitiveFailed;
 
-        SqueakObject block= (SqueakObject) rcvr;
-        Object blockArgCount= block.getPointer(Squeak.BlockContext_argumentCount);
-        if (!SqueakVM.isSmallInt(blockArgCount)) 
+        SqueakObject block = (SqueakObject) rcvr;
+        Object blockArgCount = block.getPointer(Squeak.BlockContext_argumentCount);
+        if (!SqueakVM.isSmallInt(blockArgCount))
             throw PrimitiveFailed;
-        if ((((Integer)blockArgCount).intValue()!= argCount)) 
+        if ((((Integer) blockArgCount).intValue() != argCount))
             throw PrimitiveFailed;
-        if (block.getPointer(Squeak.BlockContext_caller) != vm.nilObj) 
+        if (block.getPointer(Squeak.BlockContext_caller) != vm.nilObj)
             throw PrimitiveFailed;
-        System.arraycopy((Object)vm.activeContext.pointers,vm.sp-argCount+1,(Object)block.pointers,Squeak.Context_tempFrameStart,argCount);
-        Integer initialIP= block.getPointerI(Squeak.BlockContext_initialIP);
-        block.setPointer(Squeak.Context_instructionPointer,initialIP);
-        block.setPointer(Squeak.Context_stackPointer,new Integer(argCount));
-        block.setPointer(Squeak.BlockContext_caller,vm.activeContext);
-        vm.popN(argCount+1);
+        System.arraycopy((Object) vm.activeContext.pointers, vm.sp - argCount + 1, (Object) block.pointers, Squeak.Context_tempFrameStart, argCount);
+        Integer initialIP = block.getPointerI(Squeak.BlockContext_initialIP);
+        block.setPointer(Squeak.Context_instructionPointer, initialIP);
+        block.setPointer(Squeak.Context_stackPointer, new Integer(argCount));
+        block.setPointer(Squeak.BlockContext_caller, vm.activeContext);
+        vm.popN(argCount + 1);
         vm.newActiveContext(block);
     }
-    
-    private Object primitiveHash() 
-    {
-        Object rcvr= vm.top();
+
+    private Object primitiveHash() {
+        Object rcvr = vm.top();
         if (SqueakVM.isSmallInt(rcvr))
             throw PrimitiveFailed;
 
-        return new Integer(((SqueakObject)rcvr).hash); 
+        return new Integer(((SqueakObject) rcvr).hash);
     }
-    
-    private Object setLowSpaceThreshold() 
-    {
-        int nBytes= stackInteger(0);
-        vm.lowSpaceThreshold= nBytes;
-        return vm.stackValue(1); 
+
+    private Object setLowSpaceThreshold() {
+        int nBytes = stackInteger(0);
+        vm.lowSpaceThreshold = nBytes;
+        return vm.stackValue(1);
     }
-    
+
     // Scheduler Primitives
-    private SqueakObject getScheduler() 
-    {
-        SqueakObject assn= (SqueakObject)vm.specialObjects[Squeak.splOb_SchedulerAssociation];
-        return assn.getPointerNI(Squeak.Assn_value); 
+    private SqueakObject getScheduler() {
+        SqueakObject assn = (SqueakObject) vm.specialObjects[Squeak.splOb_SchedulerAssociation];
+        return assn.getPointerNI(Squeak.Assn_value);
     }
-    
-    private void processResume() 
-    {
-        SqueakObject process= (SqueakObject)vm.top();
-        resume(process); 
+
+    private void processResume() {
+        SqueakObject process = (SqueakObject) vm.top();
+        resume(process);
     }
-    
-    private void processSuspend() 
-    {
-        SqueakObject activeProc= getScheduler().getPointerNI(Squeak.ProcSched_activeProcess);
-        if (vm.top() != activeProc) 
+
+    private void processSuspend() {
+        SqueakObject activeProc = getScheduler().getPointerNI(Squeak.ProcSched_activeProcess);
+        if (vm.top() != activeProc)
             throw PrimitiveFailed;
-        
-        vm.popNandPush(1,vm.nilObj);
+
+        vm.popNandPush(1, vm.nilObj);
         transferTo(pickTopProcess());
     }
-    
-    private boolean isA(Object obj, int knownClass) 
-    {
-        Object itsClass= vm.getClass(obj);
-        return itsClass == vm.specialObjects[knownClass]; 
+
+    private boolean isA(Object obj, int knownClass) {
+        Object itsClass = vm.getClass(obj);
+        return itsClass == vm.specialObjects[knownClass];
     }
-    
-    private boolean isKindOf(Object obj, int knownClass) 
-    {
-        Object classOrSuper= vm.getClass(obj);
-        Object theClass= vm.specialObjects[knownClass];
-        while(classOrSuper != vm.nilObj) 
-        {
-            if (classOrSuper == theClass) 
+
+    private boolean isKindOf(Object obj, int knownClass) {
+        Object classOrSuper = vm.getClass(obj);
+        Object theClass = vm.specialObjects[knownClass];
+        while (classOrSuper != vm.nilObj) {
+            if (classOrSuper == theClass)
                 return true;
-            classOrSuper= ((SqueakObject)classOrSuper).pointers[Squeak.Class_superclass];
+            classOrSuper = ((SqueakObject) classOrSuper).pointers[Squeak.Class_superclass];
         }
-        return false; 
+        return false;
     }
-    
-    private void semaphoreWait() 
-    {
-        SqueakObject sema= (SqueakObject)vm.top();
-        if (!isA(sema,Squeak.splOb_ClassSemaphore))
+
+    private void semaphoreWait() {
+        SqueakObject sema = (SqueakObject) vm.top();
+        if (!isA(sema, Squeak.splOb_ClassSemaphore))
             throw PrimitiveFailed;
-        int excessSignals= sema.getPointerI(Squeak.Semaphore_excessSignals).intValue();
-        if (excessSignals > 0)
-        {
-            sema.setPointer(Squeak.Semaphore_excessSignals,SqueakVM.smallFromInt(excessSignals-1));
-        }
-        else 
-        {
-            SqueakObject activeProc= getScheduler().getPointerNI(Squeak.ProcSched_activeProcess);
+        int excessSignals = sema.getPointerI(Squeak.Semaphore_excessSignals).intValue();
+        if (excessSignals > 0) {
+            sema.setPointer(Squeak.Semaphore_excessSignals, SqueakVM.smallFromInt(excessSignals - 1));
+        } else {
+            SqueakObject activeProc = getScheduler().getPointerNI(Squeak.ProcSched_activeProcess);
             linkProcessToList(activeProc, sema);
-            transferTo(pickTopProcess()); 
+            transferTo(pickTopProcess());
         }
     }
-    
-    private void semaphoreSignal() 
-    {
-        SqueakObject sema= (SqueakObject)vm.top();
-        if (!isA(sema,Squeak.splOb_ClassSemaphore))
+
+    private void semaphoreSignal() {
+        SqueakObject sema = (SqueakObject) vm.top();
+        if (!isA(sema, Squeak.splOb_ClassSemaphore))
             throw PrimitiveFailed;
         synchronousSignal(sema);
     }
-    
-    void synchronousSignal(SqueakObject sema) 
-    {
-        if (isEmptyList(sema)) 
-        {
+
+    void synchronousSignal(SqueakObject sema) {
+        if (isEmptyList(sema)) {
             //no process is waiting on this semaphore"
-            int excessSignals= sema.getPointerI(Squeak.Semaphore_excessSignals).intValue();
-            sema.setPointer(Squeak.Semaphore_excessSignals,SqueakVM.smallFromInt(excessSignals+1)); 
-        }
-        else 
-        {
+            int excessSignals = sema.getPointerI(Squeak.Semaphore_excessSignals).intValue();
+            sema.setPointer(Squeak.Semaphore_excessSignals, SqueakVM.smallFromInt(excessSignals + 1));
+        } else {
             resume(removeFirstLinkOfList(sema));
         }
-        return; 
+        return;
     }
 
-    private void resume(SqueakObject newProc) 
-    {
-        SqueakObject activeProc= getScheduler().getPointerNI(Squeak.ProcSched_activeProcess);
-        int activePriority= activeProc.getPointerI(Squeak.Proc_priority).intValue();
-        int newPriority= newProc.getPointerI(Squeak.Proc_priority).intValue();
-        if (newPriority > activePriority) 
-        {
+    private void resume(SqueakObject newProc) {
+        SqueakObject activeProc = getScheduler().getPointerNI(Squeak.ProcSched_activeProcess);
+        int activePriority = activeProc.getPointerI(Squeak.Proc_priority).intValue();
+        int newPriority = newProc.getPointerI(Squeak.Proc_priority).intValue();
+        if (newPriority > activePriority) {
             putToSleep(activeProc);
-            transferTo(newProc); 
-        }
-        else 
-        {
-            putToSleep(newProc); 
+            transferTo(newProc);
+        } else {
+            putToSleep(newProc);
         }
     }
-    
-    private void putToSleep(SqueakObject aProcess) 
-    {
+
+    private void putToSleep(SqueakObject aProcess) {
         //Save the given process on the scheduler process list for its priority.
-        int priority= aProcess.getPointerI(Squeak.Proc_priority).intValue();
-        SqueakObject processLists=  getScheduler().getPointerNI(Squeak.ProcSched_processLists);
-        SqueakObject processList= processLists.getPointerNI(priority - 1);
-        linkProcessToList(aProcess, processList); 
+        int priority = aProcess.getPointerI(Squeak.Proc_priority).intValue();
+        SqueakObject processLists = getScheduler().getPointerNI(Squeak.ProcSched_processLists);
+        SqueakObject processList = processLists.getPointerNI(priority - 1);
+        linkProcessToList(aProcess, processList);
     }
-    
-    private void transferTo(SqueakObject newProc) 
-    {
+
+    private void transferTo(SqueakObject newProc) {
         //Record a process to be awakened on the next interpreter cycle.
-        SqueakObject sched=  getScheduler();
-        SqueakObject oldProc= sched.getPointerNI(Squeak.ProcSched_activeProcess);
-        sched.setPointer(Squeak.ProcSched_activeProcess,newProc);
-        oldProc.setPointer(Squeak.Proc_suspendedContext,vm.activeContext);
+        SqueakObject sched = getScheduler();
+        SqueakObject oldProc = sched.getPointerNI(Squeak.ProcSched_activeProcess);
+        sched.setPointer(Squeak.ProcSched_activeProcess, newProc);
+        oldProc.setPointer(Squeak.Proc_suspendedContext, vm.activeContext);
         //int prio= vm.intFromSmall((Integer)newProc.pointers[Squeak.Proc_priority]);
         //System.err.println("Transfer to priority " + prio + " at byteCount " + vm.byteCount);
         //if (prio==8)
         //    vm.dumpStack();
         vm.newActiveContext(newProc.getPointerNI(Squeak.Proc_suspendedContext));
         //System.err.println("new pc is " + vm.pc + "; method offset= " + ((vm.method.pointers.length+1)*4));
-        newProc.setPointer(Squeak.Proc_suspendedContext,vm.nilObj);
-        vm.reclaimableContextCount= 0; 
+        newProc.setPointer(Squeak.Proc_suspendedContext, vm.nilObj);
+        vm.reclaimableContextCount = 0;
     }
-    
+
     private SqueakObject pickTopProcess()  // aka wakeHighestPriority 
     {
         //Return the highest priority process that is ready to run.
         //Note: It is a fatal VM error if there is no runnable process.
-        SqueakObject schedLists= getScheduler().getPointerNI(Squeak.ProcSched_processLists);
-        int p= schedLists.pointersSize() - 1;  // index of last indexable field"
-        p= p - 1;
-        SqueakObject processList= schedLists.getPointerNI(p);
-        while(isEmptyList(processList)) 
-        {
-            p= p - 1;
-            if (p < 0) 
+        SqueakObject schedLists = getScheduler().getPointerNI(Squeak.ProcSched_processLists);
+        int p = schedLists.pointersSize() - 1;  // index of last indexable field"
+        p = p - 1;
+        SqueakObject processList = schedLists.getPointerNI(p);
+        while (isEmptyList(processList)) {
+            p = p - 1;
+            if (p < 0)
                 return vm.nilObj; //self error: 'scheduler could not find a runnable process' ].
-            processList= schedLists.getPointerNI(p); 
+            processList = schedLists.getPointerNI(p);
         }
-        return removeFirstLinkOfList(processList); 
-    }    
-    
-    private void linkProcessToList(SqueakObject proc, SqueakObject aList) 
-    {
+        return removeFirstLinkOfList(processList);
+    }
+
+    private void linkProcessToList(SqueakObject proc, SqueakObject aList) {
         // Add the given process to the given linked list and set the backpointer
         // of process to its new list."
-        if (isEmptyList(aList))
-        {
-            aList.setPointer(Squeak.LinkedList_firstLink,proc);
+        if (isEmptyList(aList)) {
+            aList.setPointer(Squeak.LinkedList_firstLink, proc);
+        } else {
+            SqueakObject lastLink = aList.getPointerNI(Squeak.LinkedList_lastLink);
+            lastLink.setPointer(Squeak.Link_nextLink, proc);
         }
-        else
-        {
-            SqueakObject lastLink= aList.getPointerNI(Squeak.LinkedList_lastLink);
-            lastLink.setPointer(Squeak.Link_nextLink,proc); 
-        }
-        aList.setPointer(Squeak.LinkedList_lastLink,proc);
-        proc.setPointer(Squeak.Proc_myList,aList); 
+        aList.setPointer(Squeak.LinkedList_lastLink, proc);
+        proc.setPointer(Squeak.Proc_myList, aList);
     }
-        
-    private boolean isEmptyList(SqueakObject aLinkedList) 
-    {
-        return aLinkedList.getPointerNI(Squeak.LinkedList_firstLink) == vm.nilObj; 
+
+    private boolean isEmptyList(SqueakObject aLinkedList) {
+        return aLinkedList.getPointerNI(Squeak.LinkedList_firstLink) == vm.nilObj;
     }
-    
-    private SqueakObject removeFirstLinkOfList(SqueakObject aList) 
-    {
+
+    private SqueakObject removeFirstLinkOfList(SqueakObject aList) {
         //Remove the first process from the given linked list."
-        SqueakObject first= aList.getPointerNI(Squeak.LinkedList_firstLink);
-        SqueakObject last= aList.getPointerNI(Squeak.LinkedList_lastLink);
-        if (first == last) 
-        {
-            aList.setPointer(Squeak.LinkedList_firstLink,vm.nilObj);
-            aList.setPointer(Squeak.LinkedList_lastLink,vm.nilObj); 
+        SqueakObject first = aList.getPointerNI(Squeak.LinkedList_firstLink);
+        SqueakObject last = aList.getPointerNI(Squeak.LinkedList_lastLink);
+        if (first == last) {
+            aList.setPointer(Squeak.LinkedList_firstLink, vm.nilObj);
+            aList.setPointer(Squeak.LinkedList_lastLink, vm.nilObj);
+        } else {
+            SqueakObject next = first.getPointerNI(Squeak.Link_nextLink);
+            aList.setPointer(Squeak.LinkedList_firstLink, next);
         }
-        else 
-        {
-            SqueakObject next= first.getPointerNI(Squeak.Link_nextLink);
-            aList.setPointer(Squeak.LinkedList_firstLink,next); 
-        }
-        first.setPointer(Squeak.Link_nextLink,vm.nilObj);
-        return first; 
+        first.setPointer(Squeak.Link_nextLink, vm.nilObj);
+        return first;
     }
-    
-    private SqueakObject registerSemaphore(int specialObjSpec) 
-    {
-        SqueakObject sema= (SqueakObject)vm.top();
-        if (isA(sema,Squeak.splOb_ClassSemaphore))
-            vm.specialObjects[specialObjSpec]= sema;
+
+    private SqueakObject registerSemaphore(int specialObjSpec) {
+        SqueakObject sema = (SqueakObject) vm.top();
+        if (isA(sema, Squeak.splOb_ClassSemaphore))
+            vm.specialObjects[specialObjSpec] = sema;
         else
-            vm.specialObjects[specialObjSpec]= vm.nilObj;
-        return (SqueakObject)vm.stackValue(1); 
+            vm.specialObjects[specialObjSpec] = vm.nilObj;
+        return (SqueakObject) vm.stackValue(1);
     }
-    
+
     private Object primitiveSignalAtMilliseconds()  //Delay signal:atMs: 
     {
-        int msTime= stackInteger(0);
-        Object sema= stackNonInteger(1);
-        Object rcvr= stackNonInteger(2);
+        int msTime = stackInteger(0);
+        Object sema = stackNonInteger(1);
+        Object rcvr = stackNonInteger(2);
 
         //System.err.println("Signal at " + msTime);
         //vm.dumpStack();
-        if (isA(sema,Squeak.splOb_ClassSemaphore)) 
-        {
-            vm.specialObjects[Squeak.splOb_TheTimerSemaphore]= sema;
-            vm.nextWakeupTick= msTime; 
+        if (isA(sema, Squeak.splOb_ClassSemaphore)) {
+            vm.specialObjects[Squeak.splOb_TheTimerSemaphore] = sema;
+            vm.nextWakeupTick = msTime;
+        } else {
+            vm.specialObjects[Squeak.splOb_TheTimerSemaphore] = vm.nilObj;
+            vm.nextWakeupTick = 0;
         }
-        else 
-        {
-            vm.specialObjects[Squeak.splOb_TheTimerSemaphore]= vm.nilObj;
-            vm.nextWakeupTick= 0; 
-        }
-        return rcvr; 
-    }  
+        return rcvr;
+    }
 
     //Other Primitives
-    
-    private Integer millisecondClockValue() 
-    {
+
+    private Integer millisecondClockValue() {
         //Return the value of the millisecond clock as an integer.
         //Note that the millisecond clock wraps around periodically.
         //The range is limited to SmallInteger maxVal / 2 to allow
         //delays of up to that length without overflowing a SmallInteger."
-        return SqueakVM.smallFromInt(((int) (System.currentTimeMillis() & (long)(SqueakVM.maxSmallInt>>1)))); 
+        return SqueakVM.smallFromInt(((int) (System.currentTimeMillis() & (long) (SqueakVM.maxSmallInt >> 1))));
     }
-    
-    private void beDisplay(SqueakObject displayObj) 
-    {
-        SqueakVM.FormCache disp= vm.newFormCache(displayObj);
-        if (disp.squeakForm==null) 
+
+    private void beDisplay(SqueakObject displayObj) {
+        SqueakVM.FormCache disp = vm.newFormCache(displayObj);
+        if (disp.squeakForm == null)
             throw PrimitiveFailed;
-        vm.specialObjects[Squeak.splOb_TheDisplay]= displayObj;
-        displayBitmap= disp.bits;
-        boolean remap= theDisplay != null;
-        if (remap) 
-        {
-            Dimension requestedExtent= new Dimension(disp.width, disp.height);
-            if (!theDisplay.getExtent().equals(requestedExtent)) 
-            {
+        vm.specialObjects[Squeak.splOb_TheDisplay] = displayObj;
+        displayBitmap = disp.bits;
+        boolean remap = theDisplay != null;
+        if (remap) {
+            Dimension requestedExtent = new Dimension(disp.width, disp.height);
+            if (!theDisplay.getExtent().equals(requestedExtent)) {
                 System.err.println("Squeak: changing screen size to " + disp.width + "@" + disp.height);
-                theDisplay.setExtent(requestedExtent); 
+                theDisplay.setExtent(requestedExtent);
             }
-        }
-        else 
-        {
-            theDisplay= new Screen("Squeak", disp.width,disp.height,disp.depth,vm);
-            theDisplay.getFrame().addWindowListener(new WindowAdapter() 
-            {
-                public void windowClosing(WindowEvent evt) 
-                {
-                    // TODO ask before shutdown
-                    // FIXME at least lock out quitting until concurrent image save has finished
-                	theDisplay.exit();
-                }
-            }
+        } else {
+            theDisplay = new Screen("Squeak", disp.width, disp.height, disp.depth, vm);
+            theDisplay.getFrame().addWindowListener(new WindowAdapter() {
+                                                        public void windowClosing(WindowEvent evt) {
+                                                            // TODO ask before shutdown
+                                                            // FIXME at least lock out quitting until concurrent image save has finished
+                                                            theDisplay.exit();
+                                                        }
+                                                    }
             );
         }
-        displayBitmapInBytes= new byte[displayBitmap.length*4];
-        copyBitmapToByteArray(displayBitmap,displayBitmapInBytes,
-                              new Rectangle(0,0,disp.width,disp.height),disp.pitch,disp.depth);
+        displayBitmapInBytes = new byte[displayBitmap.length * 4];
+        copyBitmapToByteArray(displayBitmap, displayBitmapInBytes,
+                new Rectangle(0, 0, disp.width, disp.height), disp.pitch, disp.depth);
         theDisplay.setBits(displayBitmapInBytes, disp.depth);
-        if (!remap) 
+        if (!remap)
             theDisplay.open();
     }
 
-    private void beCursor(int argCount) 
-    {
+    private void beCursor(int argCount) {
         // For now we ignore the white outline form (maskObj)
-        if (theDisplay == null) 
+        if (theDisplay == null)
             return;
         SqueakObject cursorObj, maskObj;
-        if (argCount==0) 
-        {
-            cursorObj= stackNonInteger(0);
-            maskObj= vm.nilObj; 
+        if (argCount == 0) {
+            cursorObj = stackNonInteger(0);
+            maskObj = vm.nilObj;
+        } else {
+            cursorObj = stackNonInteger(1);
+            maskObj = stackNonInteger(0);
         }
-        else 
-        {
-            cursorObj= stackNonInteger(1);
-            maskObj= stackNonInteger(0); 
-        }
-        SqueakVM.FormCache cursorForm= vm.newFormCache(cursorObj);
-        if ( cursorForm.squeakForm == null ) 
+        SqueakVM.FormCache cursorForm = vm.newFormCache(cursorObj);
+        if (cursorForm.squeakForm == null)
             throw PrimitiveFailed;
         //Following code for offset is not yet used...
-        SqueakObject offsetObj= checkNonSmallInt(cursorObj.getPointer(4)); 
-        if ( !isA(offsetObj,Squeak.splOb_ClassPoint))
+        SqueakObject offsetObj = checkNonSmallInt(cursorObj.getPointer(4));
+        if (!isA(offsetObj, Squeak.splOb_ClassPoint))
             throw PrimitiveFailed;
         int offsetX = checkSmallInt(offsetObj.pointers[0]);
         int offsetY = checkSmallInt(offsetObj.pointers[1]);
         //Current cursor code in Screen expects cursor and mask to be packed in cursorBytes
         //For now we make them be equal copies of incoming 16x16 cursor
-        int cursorBitsSize= cursorForm.bits.length;
-        byte[] cursorBytes= new byte[8*cursorBitsSize];
-        copyBitmapToByteArray(cursorForm.bits,cursorBytes,
-                              new Rectangle(0,0,cursorForm.width,cursorForm.height),
-                              cursorForm.pitch,cursorForm.depth);
-        for(int i=0; i<(cursorBitsSize*4); i++)
-            cursorBytes[i+(cursorBitsSize*4)]= cursorBytes[i];
-        theDisplay.setCursor(cursorBytes,BWMask);
+        int cursorBitsSize = cursorForm.bits.length;
+        byte[] cursorBytes = new byte[8 * cursorBitsSize];
+        copyBitmapToByteArray(cursorForm.bits, cursorBytes,
+                new Rectangle(0, 0, cursorForm.width, cursorForm.height),
+                cursorForm.pitch, cursorForm.depth);
+        for (int i = 0; i < (cursorBitsSize * 4); i++)
+            cursorBytes[i + (cursorBitsSize * 4)] = cursorBytes[i];
+        theDisplay.setCursor(cursorBytes, BWMask);
     }
-    
-    private void primitiveYield(int numArgs) 
-    {
+
+    private void primitiveYield(int numArgs) {
         // halts execution until EHT callbacks notify us
-        long millis= 100;
+        long millis = 100;
         if (numArgs > 1)
             throw PrimitiveFailed;
-        if (numArgs > 0) 
-        {
+        if (numArgs > 0) {
             // But, for now, wait time is ignored...
-            int micros= stackInteger(0);
+            int micros = stackInteger(0);
             vm.pop();
-            millis= micros/1000; 
+            millis = micros / 1000;
         }
         // try { synchronized (vm) { vm.wait(); }
         //         } catch (InterruptedException e) { }
         // TODO how to handle third-party interruptions?
-        try 
-        {
-            synchronized(SqueakVM.inputLock) 
-            {
-                while(!vm.screenEvent) SqueakVM.inputLock.wait(millis);
+        try {
+            synchronized (SqueakVM.inputLock) {
+                while (!vm.screenEvent) SqueakVM.inputLock.wait(millis);
             }
+        } catch (InterruptedException e) {
         }
-        catch(InterruptedException e) {}
     }
-    
-    private void primitiveCopyBits(SqueakObject rcvr, int argCount)
-    {
+
+    private void primitiveCopyBits(SqueakObject rcvr, int argCount) {
         // no rcvr class check, to allow unknown subclasses (e.g. under Turtle)
-        if (!bitbltTable.loadBitBlt(rcvr, argCount, false, (SqueakObject)vm.specialObjects[Squeak.splOb_TheDisplay])) 
+        if (!bitbltTable.loadBitBlt(rcvr, argCount, false, (SqueakObject) vm.specialObjects[Squeak.splOb_TheDisplay]))
             throw PrimitiveFailed;
-        
-        Rectangle affectedArea= bitbltTable.copyBits();
-        if (affectedArea != null && theDisplay!=null) 
-        {
-            copyBitmapToByteArray(displayBitmap,displayBitmapInBytes,affectedArea,
-                                  bitbltTable.dest.pitch,bitbltTable.dest.depth);
-            theDisplay.redisplay(false, affectedArea); 
+
+        Rectangle affectedArea = bitbltTable.copyBits();
+        if (affectedArea != null && theDisplay != null) {
+            copyBitmapToByteArray(displayBitmap, displayBitmapInBytes, affectedArea,
+                    bitbltTable.dest.pitch, bitbltTable.dest.depth);
+            theDisplay.redisplay(false, affectedArea);
         }
         if (bitbltTable.combinationRule == 22 || bitbltTable.combinationRule == 32)
-            vm.popNandPush(2,SqueakVM.smallFromInt(bitbltTable.bitCount));
+            vm.popNandPush(2, SqueakVM.smallFromInt(bitbltTable.bitCount));
     }
-    
-    private void copyBitmapToByteArray(int[] words, byte[] bytes,Rectangle rect, int raster, int depth) 
-    {
+
+    private void copyBitmapToByteArray(int[] words, byte[] bytes, Rectangle rect, int raster, int depth) {
         //Copy our 32-bit words into a byte array  until we find out
         // how to make AWT happy with int buffers
         int word;
-        int ix1= rect.x/depth/32;
-        int ix2= (rect.x+rect.width-1)/depth/32 + 1;
-        for (int y=rect.y; y<rect.y+rect.height; y++) 
-        {
-            int iy= y*raster;
-            for(int ix=ix1; ix<ix2; ix++) 
-            {
-                word= (words[iy+ix])^BWMask;
-                for(int j=0; j<4; j++)
-                    bytes[((iy+ix)*4)+j]= (byte)((word>>>((3-j)*8))&255); 
-            } 
+        int ix1 = rect.x / depth / 32;
+        int ix2 = (rect.x + rect.width - 1) / depth / 32 + 1;
+        for (int y = rect.y; y < rect.y + rect.height; y++) {
+            int iy = y * raster;
+            for (int ix = ix1; ix < ix2; ix++) {
+                word = (words[iy + ix]) ^ BWMask;
+                for (int j = 0; j < 4; j++)
+                    bytes[((iy + ix) * 4) + j] = (byte) ((word >>> ((3 - j) * 8)) & 255);
+            }
         }
-        
+
         //        int word;
         //        for(int i=0; i<words.length; i++) {
         //            word= ~(words[i]);
         //            for(int j=0; j<4; j++)
         //                bytes[(i*4)+j]= (byte)((word>>>((3-j)*8))&255); }
     }
-    
-    private SqueakObject primitiveMousePoint() 
-    {
-        SqueakObject pointClass= (SqueakObject)vm.specialObjects[Squeak.splOb_ClassPoint];
-        SqueakObject newPoint= vm.instantiateClass(pointClass,0);
-        Point lastMouse= theDisplay.getLastMousePoint();
-        newPoint.setPointer(Squeak.Point_x,SqueakVM.smallFromInt(lastMouse.x));
-        newPoint.setPointer(Squeak.Point_y,SqueakVM.smallFromInt(lastMouse.y));
-        return newPoint; 
+
+    private SqueakObject primitiveMousePoint() {
+        SqueakObject pointClass = (SqueakObject) vm.specialObjects[Squeak.splOb_ClassPoint];
+        SqueakObject newPoint = vm.instantiateClass(pointClass, 0);
+        Point lastMouse = theDisplay.getLastMousePoint();
+        newPoint.setPointer(Squeak.Point_x, SqueakVM.smallFromInt(lastMouse.x));
+        newPoint.setPointer(Squeak.Point_y, SqueakVM.smallFromInt(lastMouse.y));
+        return newPoint;
     }
-    
-    private Integer primitiveMouseButtons() 
-    {
-        return SqueakVM.smallFromInt(theDisplay.getLastMouseButtonStatus()); 
+
+    private Integer primitiveMouseButtons() {
+        return SqueakVM.smallFromInt(theDisplay.getLastMouseButtonStatus());
     }
-    
-    private Object primitiveKbdNext() 
-    {
-        return SqueakVM.smallFromInt(theDisplay.keyboardNext()); 
+
+    private Object primitiveKbdNext() {
+        return SqueakVM.smallFromInt(theDisplay.keyboardNext());
     }
-    
-    private Object primitiveKbdPeek() 
-    {
-        if (theDisplay==null) 
+
+    private Object primitiveKbdPeek() {
+        if (theDisplay == null)
             return vm.nilObj;
-        int peeked= theDisplay.keyboardPeek();
-        return peeked==0? (Object) vm.nilObj : SqueakVM.smallFromInt(peeked); 
+        int peeked = theDisplay.keyboardPeek();
+        return peeked == 0 ? (Object) vm.nilObj : SqueakVM.smallFromInt(peeked);
     }
-    
-    private SqueakObject primitiveArrayBecome(boolean doBothWays) 
-    {
+
+    private SqueakObject primitiveArrayBecome(boolean doBothWays) {
         // Should flush method cache
-        SqueakObject rcvr= stackNonInteger(1);
-        SqueakObject arg= stackNonInteger(0);
-        
-        if ( image.bulkBecome(rcvr.pointers, arg.pointers, doBothWays) )
-            return rcvr;    
-        
+        SqueakObject rcvr = stackNonInteger(1);
+        SqueakObject arg = stackNonInteger(0);
+
+        if (image.bulkBecome(rcvr.pointers, arg.pointers, doBothWays))
+            return rcvr;
+
         throw PrimitiveFailed;
     }
-    
-    private SqueakObject primitiveSomeObject() 
-    {
-        return image.nextInstance(0, null); 
+
+    private SqueakObject primitiveSomeObject() {
+        return image.nextInstance(0, null);
     }
-    
-    private SqueakObject primitiveSomeInstance(SqueakObject sqClass) 
-    {
-        return image.nextInstance(0, sqClass); 
+
+    private SqueakObject primitiveSomeInstance(SqueakObject sqClass) {
+        return image.nextInstance(0, sqClass);
     }
-    
-    private Object primitiveNextObject(SqueakObject priorObject) 
-    {
-        SqueakObject nextObject= image.nextInstance(image.otIndexOfObject(priorObject)+1, null);
-        if (nextObject==vm.nilObj)
-			return SqueakVM.smallFromInt(0);
-        return nextObject; 
+
+    private Object primitiveNextObject(SqueakObject priorObject) {
+        SqueakObject nextObject = image.nextInstance(image.otIndexOfObject(priorObject) + 1, null);
+        if (nextObject == vm.nilObj)
+            return SqueakVM.smallFromInt(0);
+        return nextObject;
     }
-    
-    private SqueakObject primitiveNextInstance(SqueakObject priorInstance) 
-    {
-        SqueakObject sqClass= (SqueakObject)priorInstance.sqClass;
-        return image.nextInstance(image.otIndexOfObject(priorInstance)+1, sqClass); 
+
+    private SqueakObject primitiveNextInstance(SqueakObject priorInstance) {
+        SqueakObject sqClass = (SqueakObject) priorInstance.sqClass;
+        return image.nextInstance(image.otIndexOfObject(priorInstance) + 1, sqClass);
     }
-    
-    private boolean relinquishProcessor() 
-    {
-        int periodInMicroseconds= stackInteger(0); //NOTE: argument is *ignored*
+
+    private boolean relinquishProcessor() {
+        int periodInMicroseconds = stackInteger(0); //NOTE: argument is *ignored*
         vm.pop();
         //        Thread.currentThread().yield();
         //        try {vm.wait(50L); } // 50 millisecond pause
         //            catch (InterruptedException e) {}
-        return true; 
+        return true;
     }
-    
-    Object primSeconds() 
-    {
+
+    Object primSeconds() {
         long currentTimeMillis = System.currentTimeMillis();
-        return squeakSeconds(currentTimeMillis); 
+        return squeakSeconds(currentTimeMillis);
     }
 
     // -- Some support methods -----------------------------------------------------------
-    
-    PrimitiveFailedException primitiveFailed()
-    {
-        return PrimitiveFailed; 
+
+    PrimitiveFailedException primitiveFailed() {
+        return PrimitiveFailed;
     }
 
     /**
      * FIXME: surely something better can be devised?
-     *        Idea: make argCount a field, then this method
-     *        needs no argument
+     * Idea: make argCount a field, then this method
+     * needs no argument
      */
-    Object stackReceiver( int argCount )
-    {
-        return vm.stackValue( argCount ); 
+    Object stackReceiver(int argCount) {
+        return vm.stackValue(argCount);
     }
 }

--- a/src/JSqueak/SqueakVM.java
+++ b/src/JSqueak/SqueakVM.java
@@ -28,27 +28,26 @@ import java.util.Arrays;
 
 /**
  * @author Daniel Ingalls
- *
+ * <p>
  * The virtual machinery for executing Squeak bytecode.
  */
-public class SqueakVM
-{
+public class SqueakVM {
     public static final Object inputLock = new Object();
     // static state:
     SqueakImage image;
     SqueakPrimitiveHandler primHandler;
-    
+
     SqueakObject nilObj;
     SqueakObject falseObj;
     SqueakObject trueObj;
     Object[] specialObjects;
     Object[] specialSelectors;
     // dynamic state:
-    Object receiver= nilObj;
-    SqueakObject activeContext= nilObj;
-    SqueakObject homeContext= nilObj;
+    Object receiver = nilObj;
+    SqueakObject activeContext = nilObj;
+    SqueakObject homeContext = nilObj;
     int sp;
-    SqueakObject method= nilObj;
+    SqueakObject method = nilObj;
     byte[] methodBytes;
     int pc;
     boolean success;
@@ -57,15 +56,15 @@ public class SqueakVM
     int reclaimableContextCount; //Not #available, but how far down the current stack is recyclable
     SqueakObject verifyAtSelector;
     SqueakObject verifyAtClass;
-    
+
     boolean screenEvent = false;
-    
+
     int lowSpaceThreshold;
     private int interruptCheckCounter;
     private int interruptCheckCounterFeedBackReset;
     private int interruptChecksEveryNms;
     private int nextPollTick;
-            int nextWakeupTick;
+    int nextWakeupTick;
     private int lastTick;
     private int interruptKeycode;
     private boolean interruptPending;
@@ -74,461 +73,718 @@ public class SqueakVM
     private int semaphoresToSignalCountB;
     private boolean deferDisplayUpdates;
     private int pendingFinalizationSignals;
-    
+
     // 31-bit small Integers, range:
-    public static int minSmallInt= -0x40000000;
-    public static int maxSmallInt=  0x3FFFFFFF;
-    public static int nonSmallInt= -0x50000000; //non-small and neg(so non pos32 too)
-    public static int millisecondClockMask= maxSmallInt>>1; //keeps ms logic in small int range
-    
-    public static int minCachedInt= -2000;
-    public static int maxCachedInt=  4000;
-    
+    public static int minSmallInt = -0x40000000;
+    public static int maxSmallInt = 0x3FFFFFFF;
+    public static int nonSmallInt = -0x50000000; //non-small and neg(so non pos32 too)
+    public static int millisecondClockMask = maxSmallInt >> 1; //keeps ms logic in small int range
+
+    public static int minCachedInt = -2000;
+    public static int maxCachedInt = 4000;
+
     static Integer[] cachedInts; // reusable SmallIntegers save space, reduce GC traffic
-    
-    static void initSmallIntegerCache() 
-    {
-        cachedInts= new Integer[maxCachedInt-minCachedInt+1];
-        for(int i=minCachedInt; i<=maxCachedInt; i++)
-            cachedInts[i-minCachedInt]= new Integer(i); 
+
+    static void initSmallIntegerCache() {
+        cachedInts = new Integer[maxCachedInt - minCachedInt + 1];
+        for (int i = minCachedInt; i <= maxCachedInt; i++)
+            cachedInts[i - minCachedInt] = new Integer(i);
     }
-    
-    class MethodCacheEntry 
-    {
+
+    class MethodCacheEntry {
         SqueakObject lkupClass;
         SqueakObject selector;
         SqueakObject method;
         int primIndex;
-        int tempCount; 
-    }
-    
-    static int methodCacheSize= 1024; // must be power of two
-    static int methodCacheMask= methodCacheSize-1; // so this is a mask
-    static int randomish= 0;
-    
-    MethodCacheEntry[] methodCache= new MethodCacheEntry[methodCacheSize];
-    
-    void initMethodCache() 
-    {
-        methodCache= new MethodCacheEntry[methodCacheSize];
-        for(int i= 0; i<methodCacheSize; i++) 
-        {
-            methodCache[i]= new MethodCacheEntry();
-        } 
+        int tempCount;
     }
 
-    int byteCount= 0;
+    static int methodCacheSize = 1024; // must be power of two
+    static int methodCacheMask = methodCacheSize - 1; // so this is a mask
+    static int randomish = 0;
+
+    MethodCacheEntry[] methodCache = new MethodCacheEntry[methodCacheSize];
+
+    void initMethodCache() {
+        methodCache = new MethodCacheEntry[methodCacheSize];
+        for (int i = 0; i < methodCacheSize; i++) {
+            methodCache[i] = new MethodCacheEntry();
+        }
+    }
+
+    int byteCount = 0;
     FileInputStream byteTracker;
-    int nRecycledContexts= 0;
-    int nAllocatedContexts= 0;
-    Object[] stackedReceivers= new Object[100];
-    Object[] stackedSelectors= new Object[100];
-    
-    
-    public SqueakVM(SqueakImage anImage)
-    {
+    int nRecycledContexts = 0;
+    int nAllocatedContexts = 0;
+    Object[] stackedReceivers = new Object[100];
+    Object[] stackedSelectors = new Object[100];
+
+
+    public SqueakVM(SqueakImage anImage) {
         // canonical creation
-        image= anImage;
+        image = anImage;
         image.bindVM(this);
-        primHandler= new SqueakPrimitiveHandler(this);
+        primHandler = new SqueakPrimitiveHandler(this);
         loadImageState();
         initVMState();
-        loadInitialContext(); 
+        loadInitialContext();
     }
-    
-    void clearCaches() 
-    {
+
+    void clearCaches() {
         // Some time store null above SP in contexts
         primHandler.clearAtCache();
         clearMethodCache();
-        freeContexts= nilObj;
-        freeLargeContexts= nilObj; 
-    }
-    
-    private void loadImageState() 
-    {
-        SqueakObject specialObjectsArray= image.specialObjectsArray;
-        specialObjects= specialObjectsArray.pointers;
-        nilObj= getSpecialObject(Squeak.splOb_NilObject);
-        falseObj= getSpecialObject(Squeak.splOb_FalseObject);
-        trueObj= getSpecialObject(Squeak.splOb_TrueObject);
-        SqueakObject ssObj= getSpecialObject(Squeak.splOb_SpecialSelectors);
-        specialSelectors= ssObj.pointers; 
+        freeContexts = nilObj;
+        freeLargeContexts = nilObj;
     }
 
-    public SqueakObject getSpecialObject(int zeroBasedIndex) 
-    {
-        return (SqueakObject) specialObjects[zeroBasedIndex]; 
-    }
-    
-    private void initVMState() 
-    {
-        interruptCheckCounter= 0;
-        interruptCheckCounterFeedBackReset= 1000;
-        interruptChecksEveryNms= 3;
-        nextPollTick= 0;
-        nextWakeupTick= 0;
-        lastTick= 0;
-        interruptKeycode= 2094;  //"cmd-."
-        interruptPending= false;
-        semaphoresUseBufferA= true;
-        semaphoresToSignalCountA= 0;
-        semaphoresToSignalCountB= 0;
-        deferDisplayUpdates= false;
-        pendingFinalizationSignals= 0;
-        freeContexts= nilObj;
-        freeLargeContexts= nilObj;
-        reclaimableContextCount= 0;
-        initMethodCache(); 
+    private void loadImageState() {
+        SqueakObject specialObjectsArray = image.specialObjectsArray;
+        specialObjects = specialObjectsArray.pointers;
+        nilObj = getSpecialObject(Squeak.splOb_NilObject);
+        falseObj = getSpecialObject(Squeak.splOb_FalseObject);
+        trueObj = getSpecialObject(Squeak.splOb_TrueObject);
+        SqueakObject ssObj = getSpecialObject(Squeak.splOb_SpecialSelectors);
+        specialSelectors = ssObj.pointers;
     }
 
-    private void loadInitialContext() 
-    {
-        SqueakObject schedAssn= getSpecialObject(Squeak.splOb_SchedulerAssociation);
-        SqueakObject sched= schedAssn.getPointerNI(Squeak.Assn_value);
-        SqueakObject proc= sched.getPointerNI(Squeak.ProcSched_activeProcess);
-        activeContext= proc.getPointerNI(Squeak.Proc_suspendedContext);
-        fetchContextRegisters (activeContext);
-        reclaimableContextCount= 0; 
+    public SqueakObject getSpecialObject(int zeroBasedIndex) {
+        return (SqueakObject) specialObjects[zeroBasedIndex];
     }
 
-    public void newActiveContext(SqueakObject newContext) 
-    {
+    private void initVMState() {
+        interruptCheckCounter = 0;
+        interruptCheckCounterFeedBackReset = 1000;
+        interruptChecksEveryNms = 3;
+        nextPollTick = 0;
+        nextWakeupTick = 0;
+        lastTick = 0;
+        interruptKeycode = 2094;  //"cmd-."
+        interruptPending = false;
+        semaphoresUseBufferA = true;
+        semaphoresToSignalCountA = 0;
+        semaphoresToSignalCountB = 0;
+        deferDisplayUpdates = false;
+        pendingFinalizationSignals = 0;
+        freeContexts = nilObj;
+        freeLargeContexts = nilObj;
+        reclaimableContextCount = 0;
+        initMethodCache();
+    }
+
+    private void loadInitialContext() {
+        SqueakObject schedAssn = getSpecialObject(Squeak.splOb_SchedulerAssociation);
+        SqueakObject sched = schedAssn.getPointerNI(Squeak.Assn_value);
+        SqueakObject proc = sched.getPointerNI(Squeak.ProcSched_activeProcess);
+        activeContext = proc.getPointerNI(Squeak.Proc_suspendedContext);
+        fetchContextRegisters(activeContext);
+        reclaimableContextCount = 0;
+    }
+
+    public void newActiveContext(SqueakObject newContext) {
         storeContextRegisters();
-        activeContext= newContext; //We're off and running...            
+        activeContext = newContext; //We're off and running...
         fetchContextRegisters(newContext);
     }
-        
-    public void fetchContextRegisters(SqueakObject ctxt) 
-    {
-        Object meth= ctxt.getPointer(Squeak.Context_method);
-        if (isSmallInt(meth)) 
-        {
+
+    public void fetchContextRegisters(SqueakObject ctxt) {
+        Object meth = ctxt.getPointer(Squeak.Context_method);
+        if (isSmallInt(meth)) {
             //if the Method field is an integer, activeCntx is a block context
-            homeContext= (SqueakObject) ctxt.getPointer(Squeak.BlockContext_home);
-            meth= homeContext.getPointerNI(Squeak.Context_method); 
-        }
-        else
-        {
+            homeContext = (SqueakObject) ctxt.getPointer(Squeak.BlockContext_home);
+            meth = homeContext.getPointerNI(Squeak.Context_method);
+        } else {
             //otherwise home==ctxt
             // if (! primHandler.isA(meth,Squeak.splOb_ClassCompiledMethod))
             //    meth= meth; // <-- break here
-            homeContext= (SqueakObject) ctxt; 
+            homeContext = (SqueakObject) ctxt;
         }
-        receiver= homeContext.getPointer(Squeak.Context_receiver);
-        method= (SqueakObject) meth;
-        methodBytes= (byte[])method.bits;
-        pc= decodeSqueakPC(ctxt.getPointerI(Squeak.Context_instructionPointer),method);
-        if (pc<-1)
+        receiver = homeContext.getPointer(Squeak.Context_receiver);
+        method = (SqueakObject) meth;
+        methodBytes = (byte[]) method.bits;
+        pc = decodeSqueakPC(ctxt.getPointerI(Squeak.Context_instructionPointer), method);
+        if (pc < -1)
             dumpStack();
-        sp= decodeSqueakSP(ctxt.getPointerI(Squeak.Context_stackPointer)); 
+        sp = decodeSqueakSP(ctxt.getPointerI(Squeak.Context_stackPointer));
     }
-    
-    public void storeContextRegisters() 
-    {
+
+    public void storeContextRegisters() {
         //Save pc, sp into activeContext object, prior to change of context
         //   see fetchContextRegisters for symmetry
         //   expects activeContext, pc, sp, and method state vars to still be valid
-        activeContext.setPointer(Squeak.Context_instructionPointer,encodeSqueakPC(pc, method));
-        activeContext.setPointer(Squeak.Context_stackPointer,encodeSqueakSP(sp)); 
+        activeContext.setPointer(Squeak.Context_instructionPointer, encodeSqueakPC(pc, method));
+        activeContext.setPointer(Squeak.Context_stackPointer, encodeSqueakSP(sp));
     }
-    
-    public Integer encodeSqueakPC(int intPC, SqueakObject aMethod) 
-    {
+
+    public Integer encodeSqueakPC(int intPC, SqueakObject aMethod) {
         // Squeak pc is offset by header and literals
         // and 1 for z-rel addressing, and 1 for pre-increment of fetch
-        return smallFromInt(intPC + (((aMethod.methodNumLits()+1)*4) + 1 + 1)); 
+        return smallFromInt(intPC + (((aMethod.methodNumLits() + 1) * 4) + 1 + 1));
     }
-        
-    public int decodeSqueakPC(Integer squeakPC, SqueakObject aMethod) 
-    {
-        return intFromSmall(squeakPC) - (((aMethod.methodNumLits()+1)*4) + 1 + 1); 
+
+    public int decodeSqueakPC(Integer squeakPC, SqueakObject aMethod) {
+        return intFromSmall(squeakPC) - (((aMethod.methodNumLits() + 1) * 4) + 1 + 1);
     }
-        
-    public Integer encodeSqueakSP(int intSP) 
-    {
+
+    public Integer encodeSqueakSP(int intSP) {
         // sp is offset by tempFrameStart, -1 for z-rel addressing
         return smallFromInt(intSP - (Squeak.Context_tempFrameStart - 1));
     }
-        
-    public int decodeSqueakSP(Integer squeakPC) 
-    {
+
+    public int decodeSqueakSP(Integer squeakPC) {
         return intFromSmall(squeakPC) + (Squeak.Context_tempFrameStart - 1);
     }
-        
+
     //SmallIntegers are stored as Java (boxed)Integers
-    public static boolean canBeSmallInt(int anInt) 
-    {
-        return (anInt >= minSmallInt) && (anInt <= maxSmallInt); 
-    }
-    
-    public static Integer smallFromInt(int raw) 
-    {
-        if (raw >= minCachedInt && raw <= maxCachedInt)
-            return cachedInts[raw-minCachedInt];
-        if (raw >= minSmallInt && raw <= maxSmallInt)
-            return new Integer (raw);
-        return null; 
-    }
-    
-    public static boolean isSmallInt(Object obj) 
-    {
-        return obj instanceof Integer; 
-    }
-    
-    public static int intFromSmall(Integer smallInt) 
-    {
-        return smallInt.intValue(); 
-    }
-    
-    // MEMORY ACCESS:
-    public SqueakObject getClass(Object obj) 
-    {
-        if (isSmallInt(obj))
-            return getSpecialObject(Squeak.splOb_ClassInteger);
-        return ((SqueakObject)obj).getSqClass();
-    }
-    
-    // STACKFRAME ACCESS:
-    public boolean isContext(SqueakObject obj) 
-    {
-        //either block or methodContext
-        if (obj.sqClass == specialObjects[Squeak.splOb_ClassMethodContext]) 
-            return true;
-        if (obj.sqClass == specialObjects[Squeak.splOb_ClassBlockContext]) 
-            return true;
-        return false;
-    }
-    
-    public boolean isMethodContext(SqueakObject obj) 
-    {
-        if (obj.sqClass == specialObjects[Squeak.splOb_ClassMethodContext]) 
-            return true;
-        return false;
-    }
-    
-    public Object pop() 
-    {
-        //Note leaves garbage above SP.  Serious reclaim should store nils above SP
-        return activeContext.pointers[sp--]; 
-    }
-    
-    public void popN(int nToPop) 
-    {
-        sp-= nToPop; 
-    }
-    
-    public void push(Object oop) 
-    {
-        activeContext.pointers[++sp] = oop; 
-    }
-    
-    public void popNandPush(int nToPop,Object oop) 
-    {
-        activeContext.pointers[sp-= nToPop-1] = oop; 
-    }
-    
-    public Object top() 
-    {
-        return activeContext.pointers[sp]; 
-    }
-    
-    public Object stackValue(int depthIntoStack) 
-    {
-        return activeContext.pointers[sp-depthIntoStack]; 
-    }
-    
-    // INNER BYTECODE INTERPRETER:
-    public int nextByte() 
-    {
-        return methodBytes[++pc] & 0xff; 
-    }
-    
-    public void run() throws java.io.IOException 
-    {
-      int b, b2;
-      while(true)
-      {
-          //...Here's the basic evaluator loop...'
-          //        printContext();
-          //        byteCount++;
-          //        int b= nextByte();        
-          b= methodBytes[++pc] & 0xff;
-          switch (b)  /* The Main Bytecode Dispatch Loop */ 
-          {
-              // load receiver variable
-              case 0: case 1: case 2: case 3: case 4: case 5: case 6: case 7: 
-              case 8: case 9: case 10: case 11: case 12: case 13: case 14: case 15: 
-                  push(((SqueakObject)receiver).getPointer(b&0xF)); break;
-      
-              // load temporary variable
-              case 16: case 17: case 18: case 19: case 20: case 21: case 22: case 23: 
-              case 24: case 25: case 26: case 27: case 28: case 29: case 30: case 31: 
-                  push(homeContext.getPointer(Squeak.Context_tempFrameStart+(b&0xF))); break;
-      
-              // loadLiteral
-              case 32: case 33: case 34: case 35: case 36: case 37: case 38: case 39: 
-              case 40: case 41: case 42: case 43: case 44: case 45: case 46: case 47: 
-              case 48: case 49: case 50: case 51: case 52: case 53: case 54: case 55: 
-              case 56: case 57: case 58: case 59: case 60: case 61: case 62: case 63: 
-                  push(method.methodGetLiteral(b&0x1F)); break;
-      
-              // loadLiteralIndirect
-              case 64: case 65: case 66: case 67: case 68: case 69: case 70: case 71: 
-              case 72: case 73: case 74: case 75: case 76: case 77: case 78: case 79: 
-              case 80: case 81: case 82: case 83: case 84: case 85: case 86: case 87: 
-              case 88: case 89: case 90: case 91: case 92: case 93: case 94: case 95: 
-                  push(((SqueakObject)method.methodGetLiteral(b&0x1F)).getPointer(Squeak.Assn_value)); break;
-      
-              // storeAndPop rcvr, temp
-              case 96: case 97: case 98: case 99: case 100: case 101: case 102: case 103: 
-                  ((SqueakObject)receiver).setPointer(b&7,pop()); break;
-              case 104: case 105: case 106: case 107: case 108: case 109: case 110: case 111: 
-                  homeContext.setPointer(Squeak.Context_tempFrameStart+(b&7),pop()); break;
-      
-              // Quick push constant
-              case 112: push(receiver); break;
-              case 113: push(trueObj); break;
-              case 114: push(falseObj); break;
-              case 115: push(nilObj); break;
-              case 116: push(smallFromInt(-1)); break;
-              case 117: push(smallFromInt(0)); break;
-              case 118: push(smallFromInt(1)); break;
-              case 119: push(smallFromInt(2)); break;
-      
-              // Quick return
-              case 120: doReturn(receiver,homeContext.getPointerNI(Squeak.Context_sender)); break;
-              case 121: doReturn(trueObj,homeContext.getPointerNI(Squeak.Context_sender)); break;
-              case 122: doReturn(falseObj,homeContext.getPointerNI(Squeak.Context_sender)); break;
-              case 123: doReturn(nilObj,homeContext.getPointerNI(Squeak.Context_sender)); break;
-              case 124: doReturn(pop(),homeContext.getPointerNI(Squeak.Context_sender)); break;
-              case 125: doReturn(pop(),activeContext.getPointerNI(Squeak.BlockContext_caller)); break;
-              case 126: nono(); break;
-              case 127: nono(); break;
-  
-              // Sundry
-              case 128: extendedPush(nextByte()); break;
-              case 129: extendedStore(nextByte()); break;
-              case 130: extendedStorePop(nextByte()); break;
-              // singleExtendedSend
-              case 131: b2= nextByte(); send(method.methodGetSelector(b2&31),b2>>5,false); break;
-              case 132: doubleExtendedDoAnything(nextByte()); break;
-              // singleExtendedSendToSuper
-              case 133: b2= nextByte(); send(method.methodGetSelector(b2&31),b2>>5,true); break;
-              // secondExtendedSend
-              case 134: b2= nextByte(); send(method.methodGetSelector(b2&63),b2>>6,false); break;
-              case 135: pop(); break; // pop
-              case 136: push(top()); break;   // dup
-              // push thisContext
-              case 137: push(activeContext); reclaimableContextCount= 0; break;
-  
-              //Unused...
-              case 138: case 139: case 140: case 141: case 142: case 143: 
-                  nono(); break;
-  
-              // Short jmp
-              case 144: case 145: case 146: case 147: case 148: case 149: case 150: case 151: 
-                  pc+= (b&7)+1; break;
-              // Short bfp
-              case 152: case 153: case 154: case 155: case 156: case 157: case 158: case 159: 
-                  jumpif (false,(b&7)+1); break;
-              // Long jump, forward and back
-              case 160: case 161: case 162: case 163: case 164: case 165: case 166: case 167: 
-                  b2=nextByte();
-                  pc+= (((b&7)-4)*256 + b2);
-                  if ((b&7)<4) checkForInterrupts();  //check on backward jumps (loops)
-                  break;
-              // Long btp
-              case 168: case 169: case 170: case 171:
-                  jumpif (true,(b&3)*256 + nextByte()); break;
-              // Long bfp
-              case 172: case 173: case 174: case 175: 
-                  jumpif (false,(b&3)*256 + nextByte()); break;
-  
-              // Arithmetic Ops... + - < > <= >= = ~=    * / \ @ lshift: lxor: land: lor:
-              case 176: success= true;
-                  if (!pop2AndPushIntResult(stackInteger(1)+stackInteger(0))) sendSpecial(b&0xF); break;   // PLUS +
-              case 177: success= true;
-                  if (!pop2AndPushIntResult(stackInteger(1)-stackInteger(0))) sendSpecial(b&0xF); break;   // PLUS +
-              case 178: success= true;
-                  if (!pushBoolAndPeek(stackInteger(1) < stackInteger(0))) sendSpecial(b&0xF); break;  // LESS <
-              case 179: success= true;
-                  if (!pushBoolAndPeek(stackInteger(1) > stackInteger(0))) sendSpecial(b&0xF); break;  // GRTR >
-              case 180: success= true;
-                  if (!pushBoolAndPeek(stackInteger(1) <= stackInteger(0)))  sendSpecial(b&0xF); break;  // LEQ <=
-              case 181: success= true;
-                  if (!pushBoolAndPeek(stackInteger(1) >= stackInteger(0)))  sendSpecial(b&0xF); break;  // GEQ >=
-              case 182: success= true;
-                  if (!pushBoolAndPeek(stackInteger(1) == stackInteger(0)))  sendSpecial(b&0xF); break;  // EQU =
-              case 183: success= true;
-                  if (!pushBoolAndPeek(stackInteger(1) != stackInteger(0)))  sendSpecial(b&0xF); break;  // NEQ ~=
-              case 184: success= true;
-                  if (!pop2AndPushIntResult(safeMultiply(stackInteger(1),stackInteger(0)))) sendSpecial(b&0xF); break;  // TIMES *
-              case 185: success= true;
-                  if (!pop2AndPushIntResult(quickDivide(stackInteger(1),stackInteger(0)))) sendSpecial(b&0xF); break;  // Divide /
-              case 186: success= true;
-                  if (!pop2AndPushIntResult(mod(stackInteger(1),stackInteger(0)))) sendSpecial(b&0xF); break;  // MOD \\
-              case 187: success= true;
-                  if (!primHandler.primitiveMakePoint()) sendSpecial(b&0xF); break;  // MakePt int@int
-              case 188: success= true; // Something is wrong with this one...
-                  /*if (!pop2AndPushIntResult(safeShift(stackInteger(1),stackInteger(0))))*/ sendSpecial(b&0xF); break; // bitShift:
-              case 189: success= true;
-                  if (!pop2AndPushIntResult(div(stackInteger(1),stackInteger(0)))) sendSpecial(b&0xF); break;  // Divide //
-              case 190: success= true;
-                  if (!pop2AndPushIntResult(stackInteger(1) & stackInteger(0))) sendSpecial(b&0xF); break; // bitAnd:
-              case 191: success= true;
-                  if (!pop2AndPushIntResult(stackInteger(1) | stackInteger(0))) sendSpecial(b&0xF); break; // bitOr:
-  
-              // at:, at:put:, size, next, nextPut:, ...
-              case 192: case 193: case 194: case 195: case 196: case 197: case 198: case 199: 
-              case 200: case 201: case 202: case 203: case 204: case 205: case 206: case 207: 
-                  if (!primHandler.quickSendOther(receiver,b&0xF))
-                      sendSpecial((b&0xF)+16); break;
-  
-              // Send Literal Selector with 0, 1, and 2 args
-              case 208: case 209: case 210: case 211: case 212: case 213: case 214: case 215: 
-              case 216: case 217: case 218: case 219: case 220: case 221: case 222: case 223: 
-                  send(method.methodGetSelector(b&0xF),0,false); break;
-              case 224: case 225: case 226: case 227: case 228: case 229: case 230: case 231: 
-              case 232: case 233: case 234: case 235: case 236: case 237: case 238: case 239: 
-                  send(method.methodGetSelector(b&0xF),1,false); break;
-              case 240: case 241: case 242: case 243: case 244: case 245: case 246: case 247: 
-              case 248: case 249: case 250: case 251: case 252: case 253: case 254: case 255:
-                  send(method.methodGetSelector(b&0xF),2,false); break; 
-          }
-      }
+    public static boolean canBeSmallInt(int anInt) {
+        return (anInt >= minSmallInt) && (anInt <= maxSmallInt);
     }
 
-    public void checkForInterrupts() 
-    {
+    public static Integer smallFromInt(int raw) {
+        if (raw >= minCachedInt && raw <= maxCachedInt)
+            return cachedInts[raw - minCachedInt];
+        if (raw >= minSmallInt && raw <= maxSmallInt)
+            return new Integer(raw);
+        return null;
+    }
+
+    public static boolean isSmallInt(Object obj) {
+        return obj instanceof Integer;
+    }
+
+    public static int intFromSmall(Integer smallInt) {
+        return smallInt.intValue();
+    }
+
+    // MEMORY ACCESS:
+    public SqueakObject getClass(Object obj) {
+        if (isSmallInt(obj))
+            return getSpecialObject(Squeak.splOb_ClassInteger);
+        return ((SqueakObject) obj).getSqClass();
+    }
+
+    // STACKFRAME ACCESS:
+    public boolean isContext(SqueakObject obj) {
+        //either block or methodContext
+        if (obj.sqClass == specialObjects[Squeak.splOb_ClassMethodContext])
+            return true;
+        if (obj.sqClass == specialObjects[Squeak.splOb_ClassBlockContext])
+            return true;
+        return false;
+    }
+
+    public boolean isMethodContext(SqueakObject obj) {
+        if (obj.sqClass == specialObjects[Squeak.splOb_ClassMethodContext])
+            return true;
+        return false;
+    }
+
+    public Object pop() {
+        //Note leaves garbage above SP.  Serious reclaim should store nils above SP
+        return activeContext.pointers[sp--];
+    }
+
+    public void popN(int nToPop) {
+        sp -= nToPop;
+    }
+
+    public void push(Object oop) {
+        activeContext.pointers[++sp] = oop;
+    }
+
+    public void popNandPush(int nToPop, Object oop) {
+        activeContext.pointers[sp -= nToPop - 1] = oop;
+    }
+
+    public Object top() {
+        return activeContext.pointers[sp];
+    }
+
+    public Object stackValue(int depthIntoStack) {
+        return activeContext.pointers[sp - depthIntoStack];
+    }
+
+    // INNER BYTECODE INTERPRETER:
+    public int nextByte() {
+        return methodBytes[++pc] & 0xff;
+    }
+
+    public void run() throws java.io.IOException {
+        int b, b2;
+        while (true) {
+            //...Here's the basic evaluator loop...'
+            //        printContext();
+            //        byteCount++;
+            //        int b= nextByte();
+            b = methodBytes[++pc] & 0xff;
+            switch (b)  /* The Main Bytecode Dispatch Loop */ {
+                // load receiver variable
+                case 0:
+                case 1:
+                case 2:
+                case 3:
+                case 4:
+                case 5:
+                case 6:
+                case 7:
+                case 8:
+                case 9:
+                case 10:
+                case 11:
+                case 12:
+                case 13:
+                case 14:
+                case 15:
+                    push(((SqueakObject) receiver).getPointer(b & 0xF));
+                    break;
+
+                // load temporary variable
+                case 16:
+                case 17:
+                case 18:
+                case 19:
+                case 20:
+                case 21:
+                case 22:
+                case 23:
+                case 24:
+                case 25:
+                case 26:
+                case 27:
+                case 28:
+                case 29:
+                case 30:
+                case 31:
+                    push(homeContext.getPointer(Squeak.Context_tempFrameStart + (b & 0xF)));
+                    break;
+
+                // loadLiteral
+                case 32:
+                case 33:
+                case 34:
+                case 35:
+                case 36:
+                case 37:
+                case 38:
+                case 39:
+                case 40:
+                case 41:
+                case 42:
+                case 43:
+                case 44:
+                case 45:
+                case 46:
+                case 47:
+                case 48:
+                case 49:
+                case 50:
+                case 51:
+                case 52:
+                case 53:
+                case 54:
+                case 55:
+                case 56:
+                case 57:
+                case 58:
+                case 59:
+                case 60:
+                case 61:
+                case 62:
+                case 63:
+                    push(method.methodGetLiteral(b & 0x1F));
+                    break;
+
+                // loadLiteralIndirect
+                case 64:
+                case 65:
+                case 66:
+                case 67:
+                case 68:
+                case 69:
+                case 70:
+                case 71:
+                case 72:
+                case 73:
+                case 74:
+                case 75:
+                case 76:
+                case 77:
+                case 78:
+                case 79:
+                case 80:
+                case 81:
+                case 82:
+                case 83:
+                case 84:
+                case 85:
+                case 86:
+                case 87:
+                case 88:
+                case 89:
+                case 90:
+                case 91:
+                case 92:
+                case 93:
+                case 94:
+                case 95:
+                    push(((SqueakObject) method.methodGetLiteral(b & 0x1F)).getPointer(Squeak.Assn_value));
+                    break;
+
+                // storeAndPop rcvr, temp
+                case 96:
+                case 97:
+                case 98:
+                case 99:
+                case 100:
+                case 101:
+                case 102:
+                case 103:
+                    ((SqueakObject) receiver).setPointer(b & 7, pop());
+                    break;
+                case 104:
+                case 105:
+                case 106:
+                case 107:
+                case 108:
+                case 109:
+                case 110:
+                case 111:
+                    homeContext.setPointer(Squeak.Context_tempFrameStart + (b & 7), pop());
+                    break;
+
+                // Quick push constant
+                case 112:
+                    push(receiver);
+                    break;
+                case 113:
+                    push(trueObj);
+                    break;
+                case 114:
+                    push(falseObj);
+                    break;
+                case 115:
+                    push(nilObj);
+                    break;
+                case 116:
+                    push(smallFromInt(-1));
+                    break;
+                case 117:
+                    push(smallFromInt(0));
+                    break;
+                case 118:
+                    push(smallFromInt(1));
+                    break;
+                case 119:
+                    push(smallFromInt(2));
+                    break;
+
+                // Quick return
+                case 120:
+                    doReturn(receiver, homeContext.getPointerNI(Squeak.Context_sender));
+                    break;
+                case 121:
+                    doReturn(trueObj, homeContext.getPointerNI(Squeak.Context_sender));
+                    break;
+                case 122:
+                    doReturn(falseObj, homeContext.getPointerNI(Squeak.Context_sender));
+                    break;
+                case 123:
+                    doReturn(nilObj, homeContext.getPointerNI(Squeak.Context_sender));
+                    break;
+                case 124:
+                    doReturn(pop(), homeContext.getPointerNI(Squeak.Context_sender));
+                    break;
+                case 125:
+                    doReturn(pop(), activeContext.getPointerNI(Squeak.BlockContext_caller));
+                    break;
+                case 126:
+                    nono();
+                    break;
+                case 127:
+                    nono();
+                    break;
+
+                // Sundry
+                case 128:
+                    extendedPush(nextByte());
+                    break;
+                case 129:
+                    extendedStore(nextByte());
+                    break;
+                case 130:
+                    extendedStorePop(nextByte());
+                    break;
+                // singleExtendedSend
+                case 131:
+                    b2 = nextByte();
+                    send(method.methodGetSelector(b2 & 31), b2 >> 5, false);
+                    break;
+                case 132:
+                    doubleExtendedDoAnything(nextByte());
+                    break;
+                // singleExtendedSendToSuper
+                case 133:
+                    b2 = nextByte();
+                    send(method.methodGetSelector(b2 & 31), b2 >> 5, true);
+                    break;
+                // secondExtendedSend
+                case 134:
+                    b2 = nextByte();
+                    send(method.methodGetSelector(b2 & 63), b2 >> 6, false);
+                    break;
+                case 135:
+                    pop();
+                    break; // pop
+                case 136:
+                    push(top());
+                    break;   // dup
+                // push thisContext
+                case 137:
+                    push(activeContext);
+                    reclaimableContextCount = 0;
+                    break;
+
+                //Unused...
+                case 138:
+                case 139:
+                case 140:
+                case 141:
+                case 142:
+                case 143:
+                    nono();
+                    break;
+
+                // Short jmp
+                case 144:
+                case 145:
+                case 146:
+                case 147:
+                case 148:
+                case 149:
+                case 150:
+                case 151:
+                    pc += (b & 7) + 1;
+                    break;
+                // Short bfp
+                case 152:
+                case 153:
+                case 154:
+                case 155:
+                case 156:
+                case 157:
+                case 158:
+                case 159:
+                    jumpif(false, (b & 7) + 1);
+                    break;
+                // Long jump, forward and back
+                case 160:
+                case 161:
+                case 162:
+                case 163:
+                case 164:
+                case 165:
+                case 166:
+                case 167:
+                    b2 = nextByte();
+                    pc += (((b & 7) - 4) * 256 + b2);
+                    if ((b & 7) < 4) checkForInterrupts();  //check on backward jumps (loops)
+                    break;
+                // Long btp
+                case 168:
+                case 169:
+                case 170:
+                case 171:
+                    jumpif(true, (b & 3) * 256 + nextByte());
+                    break;
+                // Long bfp
+                case 172:
+                case 173:
+                case 174:
+                case 175:
+                    jumpif(false, (b & 3) * 256 + nextByte());
+                    break;
+
+                // Arithmetic Ops... + - < > <= >= = ~=    * / \ @ lshift: lxor: land: lor:
+                case 176:
+                    success = true;
+                    if (!pop2AndPushIntResult(stackInteger(1) + stackInteger(0)))
+                        sendSpecial(b & 0xF);
+                    break;   // PLUS +
+                case 177:
+                    success = true;
+                    if (!pop2AndPushIntResult(stackInteger(1) - stackInteger(0)))
+                        sendSpecial(b & 0xF);
+                    break;   // PLUS +
+                case 178:
+                    success = true;
+                    if (!pushBoolAndPeek(stackInteger(1) < stackInteger(0))) sendSpecial(b & 0xF);
+                    break;  // LESS <
+                case 179:
+                    success = true;
+                    if (!pushBoolAndPeek(stackInteger(1) > stackInteger(0))) sendSpecial(b & 0xF);
+                    break;  // GRTR >
+                case 180:
+                    success = true;
+                    if (!pushBoolAndPeek(stackInteger(1) <= stackInteger(0))) sendSpecial(b & 0xF);
+                    break;  // LEQ <=
+                case 181:
+                    success = true;
+                    if (!pushBoolAndPeek(stackInteger(1) >= stackInteger(0))) sendSpecial(b & 0xF);
+                    break;  // GEQ >=
+                case 182:
+                    success = true;
+                    if (!pushBoolAndPeek(stackInteger(1) == stackInteger(0))) sendSpecial(b & 0xF);
+                    break;  // EQU =
+                case 183:
+                    success = true;
+                    if (!pushBoolAndPeek(stackInteger(1) != stackInteger(0))) sendSpecial(b & 0xF);
+                    break;  // NEQ ~=
+                case 184:
+                    success = true;
+                    if (!pop2AndPushIntResult(safeMultiply(stackInteger(1), stackInteger(0))))
+                        sendSpecial(b & 0xF);
+                    break;  // TIMES *
+                case 185:
+                    success = true;
+                    if (!pop2AndPushIntResult(quickDivide(stackInteger(1), stackInteger(0))))
+                        sendSpecial(b & 0xF);
+                    break;  // Divide /
+                case 186:
+                    success = true;
+                    if (!pop2AndPushIntResult(mod(stackInteger(1), stackInteger(0))))
+                        sendSpecial(b & 0xF);
+                    break;  // MOD \\
+                case 187:
+                    success = true;
+                    if (!primHandler.primitiveMakePoint()) sendSpecial(b & 0xF);
+                    break;  // MakePt int@int
+                case 188:
+                    success = true; // Something is wrong with this one...
+                    /*if (!pop2AndPushIntResult(safeShift(stackInteger(1),stackInteger(0))))*/
+                    sendSpecial(b & 0xF);
+                    break; // bitShift:
+                case 189:
+                    success = true;
+                    if (!pop2AndPushIntResult(div(stackInteger(1), stackInteger(0))))
+                        sendSpecial(b & 0xF);
+                    break;  // Divide //
+                case 190:
+                    success = true;
+                    if (!pop2AndPushIntResult(stackInteger(1) & stackInteger(0)))
+                        sendSpecial(b & 0xF);
+                    break; // bitAnd:
+                case 191:
+                    success = true;
+                    if (!pop2AndPushIntResult(stackInteger(1) | stackInteger(0)))
+                        sendSpecial(b & 0xF);
+                    break; // bitOr:
+
+                // at:, at:put:, size, next, nextPut:, ...
+                case 192:
+                case 193:
+                case 194:
+                case 195:
+                case 196:
+                case 197:
+                case 198:
+                case 199:
+                case 200:
+                case 201:
+                case 202:
+                case 203:
+                case 204:
+                case 205:
+                case 206:
+                case 207:
+                    if (!primHandler.quickSendOther(receiver, b & 0xF))
+                        sendSpecial((b & 0xF) + 16);
+                    break;
+
+                // Send Literal Selector with 0, 1, and 2 args
+                case 208:
+                case 209:
+                case 210:
+                case 211:
+                case 212:
+                case 213:
+                case 214:
+                case 215:
+                case 216:
+                case 217:
+                case 218:
+                case 219:
+                case 220:
+                case 221:
+                case 222:
+                case 223:
+                    send(method.methodGetSelector(b & 0xF), 0, false);
+                    break;
+                case 224:
+                case 225:
+                case 226:
+                case 227:
+                case 228:
+                case 229:
+                case 230:
+                case 231:
+                case 232:
+                case 233:
+                case 234:
+                case 235:
+                case 236:
+                case 237:
+                case 238:
+                case 239:
+                    send(method.methodGetSelector(b & 0xF), 1, false);
+                    break;
+                case 240:
+                case 241:
+                case 242:
+                case 243:
+                case 244:
+                case 245:
+                case 246:
+                case 247:
+                case 248:
+                case 249:
+                case 250:
+                case 251:
+                case 252:
+                case 253:
+                case 254:
+                case 255:
+                    send(method.methodGetSelector(b & 0xF), 2, false);
+                    break;
+            }
+        }
+    }
+
+    public void checkForInterrupts() {
         //Check for interrupts at sends and backward jumps
         SqueakObject sema;
         int now;
-        if (interruptCheckCounter-- > 0) 
+        if (interruptCheckCounter-- > 0)
             return; //only really check every 100 times or so
         //Mask so same wrap as primitiveMillisecondClock
-        now= (int) (System.currentTimeMillis() & (long)millisecondClockMask);
-        if (now < lastTick) 
-        {
+        now = (int) (System.currentTimeMillis() & (long) millisecondClockMask);
+        if (now < lastTick) {
             //millisecond clock wrapped"
-            nextPollTick= now + (nextPollTick - lastTick);
+            nextPollTick = now + (nextPollTick - lastTick);
             if (nextWakeupTick != 0)
-                nextWakeupTick= now + (nextWakeupTick - lastTick); 
+                nextWakeupTick = now + (nextWakeupTick - lastTick);
         }
         //Feedback logic attempts to keep interrupt response around 3ms...
         if ((now - lastTick) < interruptChecksEveryNms)  //wrapping is not a concern
         {
             interruptCheckCounterFeedBackReset += 10;
-        }
-        else
-        {
+        } else {
             if (interruptCheckCounterFeedBackReset <= 1000)
-                interruptCheckCounterFeedBackReset= 1000;
+                interruptCheckCounterFeedBackReset = 1000;
             else
-                interruptCheckCounterFeedBackReset -= 12; 
+                interruptCheckCounterFeedBackReset -= 12;
         }
-        interruptCheckCounter= interruptCheckCounterFeedBackReset; //reset the interrupt check counter"
-        lastTick= now; //used to detect wraparound of millisecond clock
+        interruptCheckCounter = interruptCheckCounterFeedBackReset; //reset the interrupt check counter"
+        lastTick = now; //used to detect wraparound of millisecond clock
         //  if (signalLowSpace) {
         //            signalLowSpace= false; //reset flag
         //            sema= getSpecialObject(Squeak.splOb_TheLowSpaceSemaphore);
@@ -536,19 +792,17 @@ public class SqueakVM
         //  if (now >= nextPollTick) {
         //            ioProcessEvents(); //sets interruptPending if interrupt key pressed
         //            nextPollTick= now + 500; } //msecs to wait before next call to ioProcessEvents"
-        if (interruptPending) 
-        {
-            interruptPending= false; //reset interrupt flag
-            sema= getSpecialObject(Squeak.splOb_TheInterruptSemaphore);
+        if (interruptPending) {
+            interruptPending = false; //reset interrupt flag
+            sema = getSpecialObject(Squeak.splOb_TheInterruptSemaphore);
             if (sema != nilObj)
-                primHandler.synchronousSignal(sema); 
+                primHandler.synchronousSignal(sema);
         }
-        if ((nextWakeupTick != 0) && (now >= nextWakeupTick)) 
-        {
-            nextWakeupTick= 0; //reset timer interrupt
-            sema= getSpecialObject(Squeak.splOb_TheTimerSemaphore);
-            if (sema != nilObj) 
-                primHandler.synchronousSignal(sema); 
+        if ((nextWakeupTick != 0) && (now >= nextWakeupTick)) {
+            nextWakeupTick = 0; //reset timer interrupt
+            sema = getSpecialObject(Squeak.splOb_TheTimerSemaphore);
+            if (sema != nilObj)
+                primHandler.synchronousSignal(sema);
         }
         //  if (pendingFinalizationSignals > 0) { //signal any pending finalizations
         //            sema= getSpecialObject(Squeak.splOb_ThefinalizationSemaphore);
@@ -558,427 +812,418 @@ public class SqueakVM
         //            signalExternalSemaphores(); }  //signal all semaphores in semaphoresToSignal
     }
 
-    private void jumpif (boolean condition, int delta) 
-    {
-        Object top= pop();
-        if (top == (condition? trueObj : falseObj))
-        {
-            pc+= delta; 
-            return; 
+    private void jumpif(boolean condition, int delta) {
+        Object top = pop();
+        if (top == (condition ? trueObj : falseObj)) {
+            pc += delta;
+            return;
         }
-        if (top == (condition? falseObj : trueObj))
+        if (top == (condition ? falseObj : trueObj))
             return;
         push(top); //Uh-oh it's not even a boolean (that we know of ;-).  Restore stack...
-        send((SqueakObject) specialObjects[Squeak.splOb_SelectorMustBeBoolean],1,false); 
+        send((SqueakObject) specialObjects[Squeak.splOb_SelectorMustBeBoolean], 1, false);
     }
-    
-    public void sendSpecial(int lobits) 
-    {
-        send((SqueakObject) specialSelectors[lobits*2],
-             ((Integer) specialSelectors[(lobits*2)+1]).intValue(),
-             false);   //specialSelectors is  {...sel,nArgs,sel,nArgs,...)
-    } 
-    
-    public void extendedPush(int nextByte) 
-    {
-        int lobits= nextByte&63;
-        switch (nextByte>>6) 
-        {
-            case 0: push(((SqueakObject)receiver).getPointer(lobits));break;
-            case 1: push(homeContext.getPointer(Squeak.Context_tempFrameStart+lobits)); break;
-            case 2: push(method.methodGetLiteral(lobits)); break;
-            case 3: push(((SqueakObject)method.methodGetLiteral(lobits)).getPointer(Squeak.Assn_value)); break;
+
+    public void sendSpecial(int lobits) {
+        send((SqueakObject) specialSelectors[lobits * 2],
+                ((Integer) specialSelectors[(lobits * 2) + 1]).intValue(),
+                false);   //specialSelectors is  {...sel,nArgs,sel,nArgs,...)
+    }
+
+    public void extendedPush(int nextByte) {
+        int lobits = nextByte & 63;
+        switch (nextByte >> 6) {
+            case 0:
+                push(((SqueakObject) receiver).getPointer(lobits));
+                break;
+            case 1:
+                push(homeContext.getPointer(Squeak.Context_tempFrameStart + lobits));
+                break;
+            case 2:
+                push(method.methodGetLiteral(lobits));
+                break;
+            case 3:
+                push(((SqueakObject) method.methodGetLiteral(lobits)).getPointer(Squeak.Assn_value));
+                break;
         }
     }
 
-    public void extendedStore(int nextByte) 
-    {
-        int lobits= nextByte&63;
-        switch (nextByte>>6) 
-        {
-            case 0: ((SqueakObject)receiver).setPointer(lobits,top()); break;
-            case 1: homeContext.setPointer(Squeak.Context_tempFrameStart+lobits,top()); break;
-            case 2: nono(); break;
-            case 3: ((SqueakObject)method.methodGetLiteral(lobits)).setPointer(Squeak.Assn_value,top()); break;
+    public void extendedStore(int nextByte) {
+        int lobits = nextByte & 63;
+        switch (nextByte >> 6) {
+            case 0:
+                ((SqueakObject) receiver).setPointer(lobits, top());
+                break;
+            case 1:
+                homeContext.setPointer(Squeak.Context_tempFrameStart + lobits, top());
+                break;
+            case 2:
+                nono();
+                break;
+            case 3:
+                ((SqueakObject) method.methodGetLiteral(lobits)).setPointer(Squeak.Assn_value, top());
+                break;
         }
     }
 
-    public void extendedStorePop(int nextByte) 
-    {
-        int lobits= nextByte&63;
-        switch (nextByte>>6) 
-        {
-            case 0: ((SqueakObject)receiver).setPointer(lobits,pop()); break;
-            case 1: homeContext.setPointer(Squeak.Context_tempFrameStart+lobits,pop()); break;
-            case 2: nono(); break;
-            case 3: ((SqueakObject)method.methodGetLiteral(lobits)).setPointer(Squeak.Assn_value,pop()); break;
+    public void extendedStorePop(int nextByte) {
+        int lobits = nextByte & 63;
+        switch (nextByte >> 6) {
+            case 0:
+                ((SqueakObject) receiver).setPointer(lobits, pop());
+                break;
+            case 1:
+                homeContext.setPointer(Squeak.Context_tempFrameStart + lobits, pop());
+                break;
+            case 2:
+                nono();
+                break;
+            case 3:
+                ((SqueakObject) method.methodGetLiteral(lobits)).setPointer(Squeak.Assn_value, pop());
+                break;
         }
     }
 
-    public void doubleExtendedDoAnything(int nextByte) 
-    {
-        int byte3= nextByte();
-        switch (nextByte>>5) 
-        {
-            case 0: send(method.methodGetSelector(byte3),nextByte&31,false); break;
-            case 1: send(method.methodGetSelector(byte3),nextByte&31,true); break;
-            case 2: push(((SqueakObject)receiver).getPointer(byte3)); break;
-            case 3: push(method.methodGetLiteral(byte3)); break;
-            case 4: push(((SqueakObject)method.methodGetLiteral(byte3)).getPointer(Squeak.Assn_key)); break;
-            case 5: ((SqueakObject)receiver).setPointer(byte3,top()); break;
-            case 6: ((SqueakObject)receiver).setPointer(byte3,pop()); break;
-            case 7: ((SqueakObject)method.methodGetLiteral(byte3)).setPointer(Squeak.Assn_key,top()); break;
+    public void doubleExtendedDoAnything(int nextByte) {
+        int byte3 = nextByte();
+        switch (nextByte >> 5) {
+            case 0:
+                send(method.methodGetSelector(byte3), nextByte & 31, false);
+                break;
+            case 1:
+                send(method.methodGetSelector(byte3), nextByte & 31, true);
+                break;
+            case 2:
+                push(((SqueakObject) receiver).getPointer(byte3));
+                break;
+            case 3:
+                push(method.methodGetLiteral(byte3));
+                break;
+            case 4:
+                push(((SqueakObject) method.methodGetLiteral(byte3)).getPointer(Squeak.Assn_key));
+                break;
+            case 5:
+                ((SqueakObject) receiver).setPointer(byte3, top());
+                break;
+            case 6:
+                ((SqueakObject) receiver).setPointer(byte3, pop());
+                break;
+            case 7:
+                ((SqueakObject) method.methodGetLiteral(byte3)).setPointer(Squeak.Assn_key, top());
+                break;
         }
     }
 
-    public void doReturn(Object returnValue, SqueakObject targetContext) 
-    {
-        if (targetContext==nilObj) 
+    public void doReturn(Object returnValue, SqueakObject targetContext) {
+        if (targetContext == nilObj)
             cannotReturn();
-        if (targetContext.getPointer(Squeak.Context_instructionPointer)==nilObj)
+        if (targetContext.getPointer(Squeak.Context_instructionPointer) == nilObj)
             cannotReturn();
-        SqueakObject thisContext= activeContext;
-        while (thisContext != targetContext) 
-        {
-            if (thisContext==nilObj) 
+        SqueakObject thisContext = activeContext;
+        while (thisContext != targetContext) {
+            if (thisContext == nilObj)
                 cannotReturn();
             if (isUnwindMarked(thisContext))
-                aboutToReturn(returnValue,thisContext);
-            thisContext= thisContext.getPointerNI(Squeak.Context_sender); 
+                aboutToReturn(returnValue, thisContext);
+            thisContext = thisContext.getPointerNI(Squeak.Context_sender);
         }
         //No unwind to worry about, just peel back the stack (usually just to sender)
         SqueakObject nextContext;
-        thisContext= activeContext;
-        while (thisContext != targetContext) 
-        {
-            nextContext= thisContext.getPointerNI(Squeak.Context_sender);
-            thisContext.setPointer(Squeak.Context_sender,nilObj);
-            thisContext.setPointer(Squeak.Context_instructionPointer,nilObj);
-            if (reclaimableContextCount>0) 
-            {
+        thisContext = activeContext;
+        while (thisContext != targetContext) {
+            nextContext = thisContext.getPointerNI(Squeak.Context_sender);
+            thisContext.setPointer(Squeak.Context_sender, nilObj);
+            thisContext.setPointer(Squeak.Context_instructionPointer, nilObj);
+            if (reclaimableContextCount > 0) {
                 reclaimableContextCount--;
-                recycleIfPossible(thisContext); 
+                recycleIfPossible(thisContext);
             }
-            thisContext= nextContext; 
+            thisContext = nextContext;
         }
-        activeContext= thisContext;
+        activeContext = thisContext;
         fetchContextRegisters(activeContext);
         push(returnValue);
         //System.err.println("***returning " + printString(returnValue));
     }
-    
-    public void cannotReturn() {}
-    
-    public boolean isUnwindMarked(SqueakObject ctxt) 
-    {
-        return false; 
+
+    public void cannotReturn() {
     }
-    
-    public void aboutToReturn(Object obj, SqueakObject ctxt) {}
-    
-    public void nono() 
-    {
+
+    public boolean isUnwindMarked(SqueakObject ctxt) {
+        return false;
+    }
+
+    public void aboutToReturn(Object obj, SqueakObject ctxt) {
+    }
+
+    public void nono() {
         throw new RuntimeException("bad code");
     }
-    
-    int stackInteger(int nDeep) 
-    {
-        return checkSmallInt(stackValue(nDeep)); 
+
+    int stackInteger(int nDeep) {
+        return checkSmallInt(stackValue(nDeep));
     }
-    
-    int checkSmallInt(Object maybeSmall) 
-    {
+
+    int checkSmallInt(Object maybeSmall) {
         // returns an int and sets success
         if (isSmallInt(maybeSmall))
-			return intFromSmall(((Integer)maybeSmall));
-        success= false; return 1; 
+            return intFromSmall(((Integer) maybeSmall));
+        success = false;
+        return 1;
     }
-    
-    public boolean pop2AndPushIntResult(int intResult) 
-    {
+
+    public boolean pop2AndPushIntResult(int intResult) {
         //Note returns sucess boolean
         if (!success)
             return false;
-        Object smallInt= smallFromInt(intResult);
-        if (smallInt != null)
-        {
-            popNandPush(2,smallInt); 
-            return true; 
-        }
-        return false; 
-    }
-    
-    public boolean pushBoolAndPeek(boolean boolResult) 
-    {
-        //Peek ahead to see if next bytecode is a conditional jump
-        if (!success) 
-            return false;
-        int originalPC= pc;
-        int nextByte= nextByte();
-        if (nextByte>=152 && nextByte<160)
-        {
-            // It's a BFP
-            popN(2);
-            if (boolResult) 
-                return true;
-            else 
-                pc+= (nextByte-152+1); 
+        Object smallInt = smallFromInt(intResult);
+        if (smallInt != null) {
+            popNandPush(2, smallInt);
             return true;
         }
-        if (nextByte==172) 
-        {
+        return false;
+    }
+
+    public boolean pushBoolAndPeek(boolean boolResult) {
+        //Peek ahead to see if next bytecode is a conditional jump
+        if (!success)
+            return false;
+        int originalPC = pc;
+        int nextByte = nextByte();
+        if (nextByte >= 152 && nextByte < 160) {
+            // It's a BFP
+            popN(2);
+            if (boolResult)
+                return true;
+            else
+                pc += (nextByte - 152 + 1);
+            return true;
+        }
+        if (nextByte == 172) {
             // It's a long BFP
             // Could check for all long cond jumps later
             popN(2);
-            nextByte= nextByte();
-            if (boolResult) 
+            nextByte = nextByte();
+            if (boolResult)
                 return true;
-            else 
-                pc+= nextByte; 
-            return true; 
+            else
+                pc += nextByte;
+            return true;
         }
-        popNandPush(2, boolResult? trueObj : falseObj);
-        pc= originalPC;
-        return true; 
-    }
-    
-    // Java rounds toward zero, we also need towards -infinity, so...
-    public static int div(int rcvr, int arg)
-    {
-        // do this without floats asap
-        if (arg == 0) 
-            return nonSmallInt;  // fail if divide by zero
-        return (int)Math.floor((double)rcvr/arg); 
+        popNandPush(2, boolResult ? trueObj : falseObj);
+        pc = originalPC;
+        return true;
     }
 
-    public static int quickDivide(int rcvr, int arg) 
-    {
-        // only handles exact case
-        if (arg == 0) 
+    // Java rounds toward zero, we also need towards -infinity, so...
+    public static int div(int rcvr, int arg) {
+        // do this without floats asap
+        if (arg == 0)
             return nonSmallInt;  // fail if divide by zero
-        int result= rcvr/arg;
-        if (result*arg == rcvr) 
+        return (int) Math.floor((double) rcvr / arg);
+    }
+
+    public static int quickDivide(int rcvr, int arg) {
+        // only handles exact case
+        if (arg == 0)
+            return nonSmallInt;  // fail if divide by zero
+        int result = rcvr / arg;
+        if (result * arg == rcvr)
             return result;
         return nonSmallInt;   // fail if result is not exact
     }
 
-    public static int mod(int rcvr, int arg) 
-    {
+    public static int mod(int rcvr, int arg) {
         if (arg == 0)
             return nonSmallInt;  // fail if divide by zero
-        return rcvr - div(rcvr, arg)*arg; 
+        return rcvr - div(rcvr, arg) * arg;
     }
 
-    public static int safeMultiply(int multiplicand, int multiplier) 
-    {
-        int product= multiplier * multiplicand;
+    public static int safeMultiply(int multiplicand, int multiplier) {
+        int product = multiplier * multiplicand;
         //check for overflow by seeing if computation is reversible
-        if (multiplier == 0) 
+        if (multiplier == 0)
             return product;
-        if ((product/multiplier) == multiplicand) 
+        if ((product / multiplier) == multiplicand)
             return product;
         return nonSmallInt;   //non-small result will cause failure
     }
 
-    public static int safeShift(int bitsToShift, int shiftCount) 
-    {
-        if (shiftCount<0)
-            return bitsToShift>>-shiftCount; //OK ot lose bits shifting right
+    public static int safeShift(int bitsToShift, int shiftCount) {
+        if (shiftCount < 0)
+            return bitsToShift >> -shiftCount; //OK ot lose bits shifting right
         //check for lost bits by seeing if computation is reversible
-        int shifted= bitsToShift<<shiftCount;
-        if ((shifted>>>shiftCount) == bitsToShift)
+        int shifted = bitsToShift << shiftCount;
+        if ((shifted >>> shiftCount) == bitsToShift)
             return shifted;
         return nonSmallInt;   //non-small result will cause failure 
     }
 
-    public void send(SqueakObject selector,int argCount, boolean doSuper) 
-    {
+    public void send(SqueakObject selector, int argCount, boolean doSuper) {
         SqueakObject newMethod;
         int primIndex;
-        Object newRcvr= stackValue(argCount);
+        Object newRcvr = stackValue(argCount);
         //if (printString(selector).equals("error:"))
         //  dumpStack();// <---break here
         //     int stackDepth=stackDepth();
         //     stackedReceivers[stackDepth]=newRcvr;
         //     stackedSelectors[stackDepth]=selector;
-        SqueakObject lookupClass= getClass(newRcvr);
-        if (doSuper) 
-        {
-            lookupClass= method.methodClassForSuper();
-            lookupClass= lookupClass.getPointerNI(Squeak.Class_superclass); 
+        SqueakObject lookupClass = getClass(newRcvr);
+        if (doSuper) {
+            lookupClass = method.methodClassForSuper();
+            lookupClass = lookupClass.getPointerNI(Squeak.Class_superclass);
         }
-        int priorSP= sp; // to check if DNU changes argCount
-        MethodCacheEntry entry= findSelectorInClass(selector,argCount,lookupClass);
-        newMethod= entry.method;
-        primIndex= entry.primIndex;
-        if (primIndex>0) 
-        {
+        int priorSP = sp; // to check if DNU changes argCount
+        MethodCacheEntry entry = findSelectorInClass(selector, argCount, lookupClass);
+        newMethod = entry.method;
+        primIndex = entry.primIndex;
+        if (primIndex > 0) {
             //note details for verification of at/atput primitives
-            verifyAtSelector= selector;
-            verifyAtClass= lookupClass; 
+            verifyAtSelector = selector;
+            verifyAtClass = lookupClass;
         }
-        executeNewMethod(newRcvr,newMethod,argCount+(sp-priorSP),primIndex);
+        executeNewMethod(newRcvr, newMethod, argCount + (sp - priorSP), primIndex);
     } //DNU may affest argCount
 
-    public MethodCacheEntry findSelectorInClass(SqueakObject selector, int argCount, SqueakObject startingClass) 
-    {
-        MethodCacheEntry cacheEntry= findMethodCacheEntry(selector, startingClass);
-        if (cacheEntry.method != null) 
+    public MethodCacheEntry findSelectorInClass(SqueakObject selector, int argCount, SqueakObject startingClass) {
+        MethodCacheEntry cacheEntry = findMethodCacheEntry(selector, startingClass);
+        if (cacheEntry.method != null)
             return cacheEntry; // Found it in the method cache
-        SqueakObject currentClass= startingClass;
+        SqueakObject currentClass = startingClass;
         SqueakObject mDict;
-        while(!(currentClass == nilObj)) 
-        {
-            mDict= currentClass.getPointerNI(Squeak.Class_mdict);
-            if (mDict == nilObj) 
-            {
+        while (!(currentClass == nilObj)) {
+            mDict = currentClass.getPointerNI(Squeak.Class_mdict);
+            if (mDict == nilObj) {
                 //                ["MethodDict pointer is nil (hopefully due a swapped out stub)
                 //                        -- raise exception #cannotInterpret:."
                 //                self createActualMessageTo: class.
                 //                messageSelector _ self splObj: SelectorCannotInterpret.
                 //                ^ self lookupMethodInClass: (self superclassOf: currentClass)]
             }
-            SqueakObject newMethod= lookupSelectorInDict(mDict, selector);
-            if (!(newMethod == nilObj)) 
-            {
+            SqueakObject newMethod = lookupSelectorInDict(mDict, selector);
+            if (!(newMethod == nilObj)) {
                 //load cache entry here and return
-                cacheEntry.method= newMethod;
-                cacheEntry.primIndex= newMethod.methodPrimitiveIndex();
-                return cacheEntry; 
-            }   
-            currentClass= currentClass.getPointerNI(Squeak.Class_superclass); 
+                cacheEntry.method = newMethod;
+                cacheEntry.primIndex = newMethod.methodPrimitiveIndex();
+                return cacheEntry;
+            }
+            currentClass = currentClass.getPointerNI(Squeak.Class_superclass);
         }
-        
+
         //Cound not find a normal message -- send #doesNotUnderstand:
         //if (printString(selector).equals("zork"))
         //    System.err.println(printString(selector));
-        SqueakObject dnuSel= getSpecialObject(Squeak.splOb_SelectorDoesNotUnderstand);
+        SqueakObject dnuSel = getSpecialObject(Squeak.splOb_SelectorDoesNotUnderstand);
         if (selector == dnuSel) // Cannot find #doesNotUnderstand: -- unrecoverable error.
             throw new RuntimeException("Recursive not understood error encountered");
-        SqueakObject dnuMsg= createActualMessage(selector,argCount,startingClass); //The argument to doesNotUnderstand:
-        popNandPush(argCount,dnuMsg);
-        return findSelectorInClass(dnuSel,1,startingClass); 
+        SqueakObject dnuMsg = createActualMessage(selector, argCount, startingClass); //The argument to doesNotUnderstand:
+        popNandPush(argCount, dnuMsg);
+        return findSelectorInClass(dnuSel, 1, startingClass);
     }
-    
-    public SqueakObject createActualMessage(SqueakObject selector, int argCount, SqueakObject cls) 
-    {
+
+    public SqueakObject createActualMessage(SqueakObject selector, int argCount, SqueakObject cls) {
         //Bundle up receiver, args and selector as a messageObject
-        SqueakObject argArray= instantiateClass(getSpecialObject(Squeak.splOb_ClassArray),argCount);
-        System.arraycopy(activeContext.pointers,sp-argCount+1,argArray.pointers,0,argCount); //copy args from stack
-        SqueakObject message= instantiateClass(getSpecialObject(Squeak.splOb_ClassMessage),0);
-        message.setPointer(Squeak.Message_selector,selector);
-        message.setPointer(Squeak.Message_arguments,argArray);
-        if (message.pointers.length<3)
+        SqueakObject argArray = instantiateClass(getSpecialObject(Squeak.splOb_ClassArray), argCount);
+        System.arraycopy(activeContext.pointers, sp - argCount + 1, argArray.pointers, 0, argCount); //copy args from stack
+        SqueakObject message = instantiateClass(getSpecialObject(Squeak.splOb_ClassMessage), 0);
+        message.setPointer(Squeak.Message_selector, selector);
+        message.setPointer(Squeak.Message_arguments, argArray);
+        if (message.pointers.length < 3)
             return message; //Early versions don't have lookupClass
-        message.setPointer(Squeak.Message_lookupClass,cls);
-        return message; 
+        message.setPointer(Squeak.Message_lookupClass, cls);
+        return message;
     }
-    
-    public SqueakObject lookupSelectorInDict(SqueakObject mDict, SqueakObject messageSelector) 
-    {
+
+    public SqueakObject lookupSelectorInDict(SqueakObject mDict, SqueakObject messageSelector) {
         //Returns a method or nilObject
-        int dictSize= mDict.pointersSize();
-        int mask= (dictSize - Squeak.MethodDict_selectorStart)-1;
-        int index= (mask & messageSelector.hash) + Squeak.MethodDict_selectorStart;
+        int dictSize = mDict.pointersSize();
+        int mask = (dictSize - Squeak.MethodDict_selectorStart) - 1;
+        int index = (mask & messageSelector.hash) + Squeak.MethodDict_selectorStart;
         // If there are no nils(should always be), then stop looping on second wrap.
-        boolean hasWrapped= false;
-        while (true) 
-        {
-            SqueakObject nextSelector= mDict.getPointerNI(index);
+        boolean hasWrapped = false;
+        while (true) {
+            SqueakObject nextSelector = mDict.getPointerNI(index);
             //System.err.println("index= "+index+" "+printString(nextSelector));
-            if (nextSelector==messageSelector) 
-            {
-                SqueakObject methArray= mDict.getPointerNI(Squeak.MethodDict_array);
-                return methArray.getPointerNI(index-Squeak.MethodDict_selectorStart); 
+            if (nextSelector == messageSelector) {
+                SqueakObject methArray = mDict.getPointerNI(Squeak.MethodDict_array);
+                return methArray.getPointerNI(index - Squeak.MethodDict_selectorStart);
             }
-            if (nextSelector==nilObj)
+            if (nextSelector == nilObj)
                 return nilObj;
-            if (++index == dictSize) 
-            {
-                if (hasWrapped) 
+            if (++index == dictSize) {
+                if (hasWrapped)
                     return nilObj;
-                index= Squeak.MethodDict_selectorStart;
-                hasWrapped= true; 
+                index = Squeak.MethodDict_selectorStart;
+                hasWrapped = true;
             }
         }
     }
-    
-    public void executeNewMethod(Object newRcvr,SqueakObject newMethod,int argumentCount,int primitiveIndex) 
-    {
-        if (primitiveIndex>0)
-            if (tryPrimitive(primitiveIndex,argumentCount))
+
+    public void executeNewMethod(Object newRcvr, SqueakObject newMethod, int argumentCount, int primitiveIndex) {
+        if (primitiveIndex > 0)
+            if (tryPrimitive(primitiveIndex, argumentCount))
                 return;  //Primitive succeeded -- end of story
-        SqueakObject newContext= allocateOrRecycleContext(newMethod.methodNeedsLargeFrame());
-        int methodNumLits= method.methodNumLits();
+        SqueakObject newContext = allocateOrRecycleContext(newMethod.methodNeedsLargeFrame());
+        int methodNumLits = method.methodNumLits();
         //Our initial IP is -1, so first fetch gets bits[0]
         //The stored IP should be 1-based index of *next* instruction, offset by hdr and lits
-        int newPC= -1;
-        int tempCount= newMethod.methodTempCount();
-        int newSP= tempCount;
-        newSP+= Squeak.Context_tempFrameStart - 1; //-1 for z-rel addressing
-        newContext.setPointer(Squeak.Context_method,newMethod);
+        int newPC = -1;
+        int tempCount = newMethod.methodTempCount();
+        int newSP = tempCount;
+        newSP += Squeak.Context_tempFrameStart - 1; //-1 for z-rel addressing
+        newContext.setPointer(Squeak.Context_method, newMethod);
         //Following store is in case we alloc without init; all other fields get stored
-        newContext.setPointer(Squeak.BlockContext_initialIP,nilObj);
-        newContext.setPointer(Squeak.Context_sender,activeContext);
+        newContext.setPointer(Squeak.BlockContext_initialIP, nilObj);
+        newContext.setPointer(Squeak.Context_sender, activeContext);
         //Copy receiver and args to new context
         //Note this statement relies on the receiver slot being contiguous with args...
-        System.arraycopy(activeContext.pointers,sp-argumentCount,newContext.pointers,Squeak.Context_tempFrameStart-1,argumentCount+1);
+        System.arraycopy(activeContext.pointers, sp - argumentCount, newContext.pointers, Squeak.Context_tempFrameStart - 1, argumentCount + 1);
         //...and fill the remaining temps with nil
-        Arrays.fill(newContext.pointers,Squeak.Context_tempFrameStart+argumentCount,Squeak.Context_tempFrameStart+tempCount,nilObj);
-        popN(argumentCount+1);
+        Arrays.fill(newContext.pointers, Squeak.Context_tempFrameStart + argumentCount, Squeak.Context_tempFrameStart + tempCount, nilObj);
+        popN(argumentCount + 1);
         reclaimableContextCount++;
         storeContextRegisters();
-        activeContext= newContext; //We're off and running...            
+        activeContext = newContext; //We're off and running...
         //      Following are more efficient than fetchContextRegisters in newActiveContext:
-        homeContext= newContext;
-        method= newMethod;
-        methodBytes= (byte[])method.bits;
-        pc= newPC;
-        sp= newSP;
+        homeContext = newContext;
+        method = newMethod;
+        methodBytes = (byte[]) method.bits;
+        pc = newPC;
+        sp = newSP;
         storeContextRegisters(); // not really necessary, I claim
-        receiver= newContext.getPointer(Squeak.Context_receiver);
-        if (receiver != newRcvr) 
+        receiver = newContext.getPointer(Squeak.Context_receiver);
+        if (receiver != newRcvr)
             System.err.println("receiver doesnt match");
-        checkForInterrupts(); 
+        checkForInterrupts();
     }
-    
-    public boolean tryPrimitive(int primIndex, int argCount) 
-    {
-        if ((primIndex > 255) && (primIndex < 520)) 
-        {
-            if (primIndex >= 264) 
-            {
+
+    public boolean tryPrimitive(int primIndex, int argCount) {
+        if ((primIndex > 255) && (primIndex < 520)) {
+            if (primIndex >= 264) {
                 //return instvars
-                popNandPush(1,((SqueakObject)top()).getPointer(primIndex-264));
-                return true; 
-            }
-            else 
-            {
+                popNandPush(1, ((SqueakObject) top()).getPointer(primIndex - 264));
+                return true;
+            } else {
                 if (primIndex == 256)
                     return true; //return self
-                if (primIndex == 257) 
-                {
-                    popNandPush(1,trueObj); //return true
-                    return true; 
+                if (primIndex == 257) {
+                    popNandPush(1, trueObj); //return true
+                    return true;
                 }
-                if (primIndex == 258) 
-                {
-                    popNandPush(1,falseObj); //return false
-                    return true; 
+                if (primIndex == 258) {
+                    popNandPush(1, falseObj); //return false
+                    return true;
                 }
-                if (primIndex == 259) 
-                {
-                    popNandPush(1,nilObj); //return nil
-                    return true; 
+                if (primIndex == 259) {
+                    popNandPush(1, nilObj); //return nil
+                    return true;
                 }
-                popNandPush(1,smallFromInt(primIndex-261)); //return -1...2
-                return true; 
+                popNandPush(1, smallFromInt(primIndex - 261)); //return -1...2
+                return true;
             }
-        }
-        else 
-        {
-            int spBefore= sp;
-            boolean success= primHandler.doPrimitive(primIndex, argCount);
+        } else {
+            int spBefore = sp;
+            boolean success = primHandler.doPrimitive(primIndex, argCount);
 //            if (success) {
 //                if (primIndex>=81 && primIndex<=88) return success; // context switches and perform
 //                if (primIndex>=43 && primIndex<=48) return success; // boolean peeks
@@ -995,173 +1240,147 @@ public class SqueakVM
 //                    dumpStack();
 //                    int a=primIndex; } // <-- break here
 //                }
-            return success; 
+            return success;
         }
     }
 
-    public boolean primitivePerform(int argCount) 
-    {
-        SqueakObject selector= (SqueakObject)stackValue(argCount-1);
-        Object rcvr= stackValue(argCount);
+    public boolean primitivePerform(int argCount) {
+        SqueakObject selector = (SqueakObject) stackValue(argCount - 1);
+        Object rcvr = stackValue(argCount);
         //      NOTE: findNewMethodInClass may fail and be converted to #doesNotUnderstand:,
         //            (Whoah) so we must slide args down on the stack now, so that would work
-        int trueArgCount= argCount - 1;
-        int selectorIndex= sp - trueArgCount;
-        Object[] stack= activeContext.pointers; // slide eveything down...
-        System.arraycopy(stack,selectorIndex+1,stack,selectorIndex,trueArgCount);
+        int trueArgCount = argCount - 1;
+        int selectorIndex = sp - trueArgCount;
+        Object[] stack = activeContext.pointers; // slide eveything down...
+        System.arraycopy(stack, selectorIndex + 1, stack, selectorIndex, trueArgCount);
         sp--; // adjust sp accordingly
-        MethodCacheEntry entry= findSelectorInClass(selector,trueArgCount,getClass(rcvr));
-        SqueakObject newMethod= entry.method;
-        executeNewMethod(rcvr,newMethod,newMethod.methodNumArgs(),entry.primIndex);
-        return true; 
+        MethodCacheEntry entry = findSelectorInClass(selector, trueArgCount, getClass(rcvr));
+        SqueakObject newMethod = entry.method;
+        executeNewMethod(rcvr, newMethod, newMethod.methodNumArgs(), entry.primIndex);
+        return true;
     }
-                                        
-    public boolean primitivePerformWithArgs(SqueakObject lookupClass) 
-    {
-        Object rcvr= stackValue(2);
-        SqueakObject selector= (SqueakObject)stackValue(1);
-        if (isSmallInt(stackValue(0))) 
+
+    public boolean primitivePerformWithArgs(SqueakObject lookupClass) {
+        Object rcvr = stackValue(2);
+        SqueakObject selector = (SqueakObject) stackValue(1);
+        if (isSmallInt(stackValue(0)))
             return false;
-        SqueakObject args= (SqueakObject)stackValue(0);
-        if (args.pointers==null)
+        SqueakObject args = (SqueakObject) stackValue(0);
+        if (args.pointers == null)
             return false;
-        int trueArgCount= args.pointers.length;
-        System.arraycopy(args.pointers,0,activeContext.pointers,sp-1,trueArgCount);
-        sp= sp-2+trueArgCount; //pop selector and array then push args
-        MethodCacheEntry entry= findSelectorInClass(selector,trueArgCount,lookupClass);
-        SqueakObject newMethod= entry.method;
-        if (newMethod.methodNumArgs() != trueArgCount) 
+        int trueArgCount = args.pointers.length;
+        System.arraycopy(args.pointers, 0, activeContext.pointers, sp - 1, trueArgCount);
+        sp = sp - 2 + trueArgCount; //pop selector and array then push args
+        MethodCacheEntry entry = findSelectorInClass(selector, trueArgCount, lookupClass);
+        SqueakObject newMethod = entry.method;
+        if (newMethod.methodNumArgs() != trueArgCount)
             return false;
-        executeNewMethod(rcvr,newMethod,newMethod.methodNumArgs(),entry.primIndex);
-        return true; 
+        executeNewMethod(rcvr, newMethod, newMethod.methodNumArgs(), entry.primIndex);
+        return true;
     }
-                                        
-    public boolean primitivePerformInSuperclass(SqueakObject lookupClass) 
-    {
+
+    public boolean primitivePerformInSuperclass(SqueakObject lookupClass) {
         //verify that lookupClass is actually in reciver's inheritance
-        SqueakObject currentClass= getClass(stackValue(3));
-        while(currentClass != lookupClass) 
-        {
-            currentClass= (SqueakObject)currentClass.pointers[Squeak.Class_superclass];
-            if (currentClass == nilObj) 
-                return false; 
+        SqueakObject currentClass = getClass(stackValue(3));
+        while (currentClass != lookupClass) {
+            currentClass = (SqueakObject) currentClass.pointers[Squeak.Class_superclass];
+            if (currentClass == nilObj)
+                return false;
         }
         pop(); //pop the lookupClass for now
-        if (primitivePerformWithArgs(lookupClass)) 
+        if (primitivePerformWithArgs(lookupClass))
             return true;
         push(lookupClass); //restore lookupClass if failed
-        return false; 
+        return false;
     }
-                                        
-    public void recycleIfPossible(SqueakObject ctxt) 
-    {
+
+    public void recycleIfPossible(SqueakObject ctxt) {
         if (!isMethodContext(ctxt))
             return;
         //if (isContext(ctxt)) return; //Defeats recycling of contexts
-        if (ctxt.pointersSize() == (Squeak.Context_tempFrameStart+Squeak.Context_smallFrameSize))
-        {
+        if (ctxt.pointersSize() == (Squeak.Context_tempFrameStart + Squeak.Context_smallFrameSize)) {
             // Recycle small contexts
-            ctxt.setPointer(0,freeContexts);
-            freeContexts= ctxt; 
-        }
-        else 
-        {
+            ctxt.setPointer(0, freeContexts);
+            freeContexts = ctxt;
+        } else {
             // Recycle large contexts
-            if (ctxt.pointersSize() != (Squeak.Context_tempFrameStart+Squeak.Context_largeFrameSize))
-            {
+            if (ctxt.pointersSize() != (Squeak.Context_tempFrameStart + Squeak.Context_largeFrameSize)) {
                 // freeContexts=freeContexts;
                 return;  //  <-- break here
             }
-            ctxt.setPointer(0,freeLargeContexts);
-            freeLargeContexts= ctxt; 
-        }
-    }
-    
-    public SqueakObject allocateOrRecycleContext(boolean needsLarge) 
-    {
-        //Return a recycled context or a newly allocated one if none is available for recycling."
-        SqueakObject freebie;
-        if (needsLarge) 
-        {
-            if (freeLargeContexts != nilObj) 
-            {
-                freebie= freeLargeContexts;
-                freeLargeContexts= freebie.getPointerNI(0);
-                nRecycledContexts++;
-                return freebie; 
-            }
-            nAllocatedContexts++;
-            return instantiateClass((SqueakObject)specialObjects[Squeak.splOb_ClassMethodContext],
-                                    Squeak.Context_largeFrameSize); 
-        }
-        else 
-        {
-            if (freeContexts != nilObj) 
-            {
-                freebie= freeContexts;
-                freeContexts= freebie.getPointerNI(0);
-                nRecycledContexts++;
-                return freebie; 
-            }
-            nAllocatedContexts++;
-            return instantiateClass((SqueakObject)specialObjects[Squeak.splOb_ClassMethodContext],
-                                    Squeak.Context_smallFrameSize); 
+            ctxt.setPointer(0, freeLargeContexts);
+            freeLargeContexts = ctxt;
         }
     }
 
-    public SqueakObject instantiateClass( int specialObjectClassIndex,int indexableSize)
-    {
-        return instantiateClass( (SqueakObject) specialObjects[specialObjectClassIndex], 
-                                 indexableSize );
+    public SqueakObject allocateOrRecycleContext(boolean needsLarge) {
+        //Return a recycled context or a newly allocated one if none is available for recycling."
+        SqueakObject freebie;
+        if (needsLarge) {
+            if (freeLargeContexts != nilObj) {
+                freebie = freeLargeContexts;
+                freeLargeContexts = freebie.getPointerNI(0);
+                nRecycledContexts++;
+                return freebie;
+            }
+            nAllocatedContexts++;
+            return instantiateClass((SqueakObject) specialObjects[Squeak.splOb_ClassMethodContext],
+                    Squeak.Context_largeFrameSize);
+        } else {
+            if (freeContexts != nilObj) {
+                freebie = freeContexts;
+                freeContexts = freebie.getPointerNI(0);
+                nRecycledContexts++;
+                return freebie;
+            }
+            nAllocatedContexts++;
+            return instantiateClass((SqueakObject) specialObjects[Squeak.splOb_ClassMethodContext],
+                    Squeak.Context_smallFrameSize);
+        }
     }
-    
+
+    public SqueakObject instantiateClass(int specialObjectClassIndex, int indexableSize) {
+        return instantiateClass((SqueakObject) specialObjects[specialObjectClassIndex],
+                indexableSize);
+    }
+
     // FIXME: remove this method
-    public SqueakObject instantiateClass(SqueakObject theClass,int indexableSize) 
-    {
-        return new SqueakObject(image,theClass,indexableSize,nilObj); 
+    public SqueakObject instantiateClass(SqueakObject theClass, int indexableSize) {
+        return new SqueakObject(image, theClass, indexableSize, nilObj);
     }
-    
-    public boolean clearMethodCache() 
-    {
+
+    public boolean clearMethodCache() {
         //clear method cache entirely (prim 89)
-        for(int i= 0; i<methodCacheSize; i++) 
-        {
-            methodCache[i].selector= null;   // mark it free
-            methodCache[i].method= null;     // release the method 
+        for (int i = 0; i < methodCacheSize; i++) {
+            methodCache[i].selector = null;   // mark it free
+            methodCache[i].method = null;     // release the method
         }
-        return true; 
+        return true;
     }
-    
-    public boolean flushMethodCacheForSelector(SqueakObject selector)
-    {
+
+    public boolean flushMethodCacheForSelector(SqueakObject selector) {
         //clear cache entries for selector (prim 119)
-        for(int i= 0; i<methodCacheSize; i++) 
-        {
-            if (methodCache[i].selector==selector) 
-            {
-                methodCache[i].selector= null;   // mark it free
-                methodCache[i].method= null;   // release the method 
+        for (int i = 0; i < methodCacheSize; i++) {
+            if (methodCache[i].selector == selector) {
+                methodCache[i].selector = null;   // mark it free
+                methodCache[i].method = null;   // release the method
             }
         }
-        return true; 
+        return true;
     }
-    
-    public boolean flushMethodCacheForMethod(SqueakObject method) 
-    {
+
+    public boolean flushMethodCacheForMethod(SqueakObject method) {
         //clear cache entries for selector (prim 116)
-        for(int i= 0; i<methodCacheSize; i++) 
-        {
-            if (methodCache[i].method==method) 
-            {
-                methodCache[i].selector= null;   // mark it free
-                methodCache[i].method= null;   // release the method 
+        for (int i = 0; i < methodCacheSize; i++) {
+            if (methodCache[i].method == method) {
+                methodCache[i].selector = null;   // mark it free
+                methodCache[i].method = null;   // release the method
             }
         }
-        return true; 
+        return true;
     }
-    
-    public MethodCacheEntry findMethodCacheEntry(SqueakObject selector, SqueakObject lkupClass) 
-    {
+
+    public MethodCacheEntry findMethodCacheEntry(SqueakObject selector, SqueakObject lkupClass) {
         //Probe the cache, and return the matching entry if found
         //Otherwise return one that can be used (selector and class set) with method= null.
         //Initial probe is class xor selector, reprobe delta is selector
@@ -1169,85 +1388,76 @@ public class SqueakVM
         //Instead we randomize the reprobe so two or three very active conflicting entries
         //will not keep dislodging each other
         MethodCacheEntry entry;
-        int nProbes= 4;
-        randomish= (randomish+1)%nProbes;
-        int firstProbe= (selector.hash^lkupClass.hash)&methodCacheMask;
-        int probe= firstProbe;
-        for(int i=0; i<4; i++) 
-        {
+        int nProbes = 4;
+        randomish = (randomish + 1) % nProbes;
+        int firstProbe = (selector.hash ^ lkupClass.hash) & methodCacheMask;
+        int probe = firstProbe;
+        for (int i = 0; i < 4; i++) {
             // 4 reprobes for now
-            entry= methodCache[probe];
-            if (entry.selector == selector && entry.lkupClass == lkupClass) 
+            entry = methodCache[probe];
+            if (entry.selector == selector && entry.lkupClass == lkupClass)
                 return entry;
-            if (i==randomish)
-                firstProbe= probe;
-            probe= (probe + selector.hash) & methodCacheMask; 
+            if (i == randomish)
+                firstProbe = probe;
+            probe = (probe + selector.hash) & methodCacheMask;
         }
-        entry= methodCache[firstProbe];
-        entry.lkupClass= lkupClass;
-        entry.selector= selector;
-        entry.method= null;
-        return entry; 
+        entry = methodCache[firstProbe];
+        entry.lkupClass = lkupClass;
+        entry.selector = selector;
+        entry.method = null;
+        return entry;
     }
-    
-    public void printContext() 
-    {
-        if ((byteCount%100)==0 && stackDepth()>100) 
-        {
+
+    public void printContext() {
+        if ((byteCount % 100) == 0 && stackDepth() > 100) {
             System.err.println("******Stack depth over 100******");
             dumpStack();
             // byteCount= byteCount;  // <-- break here
         }
         //        if (mod(byteCount,1000) != 0) return;
-        if (byteCount != -1) 
+        if (byteCount != -1)
             return;
         System.err.println();
         System.err.println(byteCount + " rcvr= " + printString(receiver));
         System.err.println("depth= " + stackDepth() + "; top= " + printString(top()));
-        System.err.println("pc= " + pc + "; sp= " + sp + "; nextByte= " + (((byte[])method.bits)[pc+1] & 0xff));
+        System.err.println("pc= " + pc + "; sp= " + sp + "; nextByte= " + (((byte[]) method.bits)[pc + 1] & 0xff));
         // if (byteCount==1764)
         //    byteCount= byteCount;  // <-- break here 
     }
 
-    int stackDepth() 
-    {
-        SqueakObject ctxt= activeContext;
-        int depth= 0;
-        while((ctxt= ctxt.getPointerNI(Squeak.Context_sender)) != nilObj)
-            depth= depth+1;
-        return depth; 
+    int stackDepth() {
+        SqueakObject ctxt = activeContext;
+        int depth = 0;
+        while ((ctxt = ctxt.getPointerNI(Squeak.Context_sender)) != nilObj)
+            depth = depth + 1;
+        return depth;
     }
-    
-    String printString(Object obj) 
-    {
+
+    String printString(Object obj) {
         //Handles SqueakObjs and SmallInts as well
-        if (obj==null) 
+        if (obj == null)
             return "null";
-        if (isSmallInt(obj)) 
+        if (isSmallInt(obj))
             return "=" + ((Integer) obj).intValue();
-        else 
-            return ((SqueakObject) obj).asString(); 
+        else
+            return ((SqueakObject) obj).asString();
     }
-    
-    void dumpStack() 
-    {
-        for(int i=0; i<stackDepth(); i++)
-            if (stackedSelectors!=null)
-                System.err.println(stackedReceivers[i] + " >> " + stackedSelectors[i]); 
+
+    void dumpStack() {
+        for (int i = 0; i < stackDepth(); i++)
+            if (stackedSelectors != null)
+                System.err.println(stackedReceivers[i] + " >> " + stackedSelectors[i]);
     }
-    
-    FormCache newFormCache(SqueakObject aForm) 
-    {
-        return new FormCache(aForm); 
+
+    FormCache newFormCache(SqueakObject aForm) {
+        return new FormCache(aForm);
     }
-    
-    FormCache newFormCache() 
-    {
-        return new FormCache(); 
+
+    FormCache newFormCache() {
+        return new FormCache();
     }
-    
-    public class FormCache 
-    {
+
+    public class FormCache {
         SqueakObject squeakForm;
         int[] bits;
         int width;
@@ -1256,70 +1466,65 @@ public class SqueakVM
         boolean msb;
         int pixPerWord;
         int pitch; // aka raster
-        
-        FormCache() {}
-        
-        FormCache(SqueakObject obj)
-        {
-            this.loadFrom(obj); 
+
+        FormCache() {
         }
-        
-        boolean loadFrom(Object aForm) 
-        {
+
+        FormCache(SqueakObject obj) {
+            this.loadFrom(obj);
+        }
+
+        boolean loadFrom(Object aForm) {
             //We do not reload if this is the same form as before
-            if (squeakForm == aForm) 
+            if (squeakForm == aForm)
                 return true;
-            squeakForm= null; //Marks this as failed until very end...
-            if (isSmallInt(aForm)) 
+            squeakForm = null; //Marks this as failed until very end...
+            if (isSmallInt(aForm))
                 return false;
-            Object[] formPointers= ((SqueakObject)aForm).pointers;
-            if (formPointers == null || formPointers.length<4)  
+            Object[] formPointers = ((SqueakObject) aForm).pointers;
+            if (formPointers == null || formPointers.length < 4)
                 return false;
-            for(int i=1; i<4; i++)
-                if (!isSmallInt(formPointers[i])) 
+            for (int i = 1; i < 4; i++)
+                if (!isSmallInt(formPointers[i]))
                     return false;
             Object bitsObject = formPointers[0];
-            width = intFromSmall(((Integer)formPointers[1]));
-            height = intFromSmall(((Integer)formPointers[2]));
-            depth = intFromSmall(((Integer)formPointers[3]));
-            if ((width < 0) || (height < 0)) 
+            width = intFromSmall(((Integer) formPointers[1]));
+            height = intFromSmall(((Integer) formPointers[2]));
+            depth = intFromSmall(((Integer) formPointers[3]));
+            if ((width < 0) || (height < 0))
                 return false;
-            if (bitsObject==nilObj || isSmallInt(bitsObject)) 
+            if (bitsObject == nilObj || isSmallInt(bitsObject))
                 return false;
             msb = depth > 0;
             if (depth < 0)
                 depth = 0 - depth;
-            Object maybeBytes= ((SqueakObject)bitsObject).bits;
-            if (maybeBytes == null || maybeBytes instanceof byte[]) 
+            Object maybeBytes = ((SqueakObject) bitsObject).bits;
+            if (maybeBytes == null || maybeBytes instanceof byte[])
                 return false;  //Happens with compressed bits
-            bits= (int[])maybeBytes;
+            bits = (int[]) maybeBytes;
             pixPerWord = 32 / depth;
             pitch = (width + (pixPerWord - 1)) / pixPerWord;
-            if (bits.length != (pitch * height)) 
+            if (bits.length != (pitch * height))
                 return false;
-            squeakForm= (SqueakObject)aForm; //Only now is it marked as OK
-            return true; 
+            squeakForm = (SqueakObject) aForm; //Only now is it marked as OK
+            return true;
         }
     }
-    
-    void wakeVM() 
-    {
+
+    void wakeVM() {
         screenEvent = true;
-        synchronized(this)
-        {
-            notify(); 
+        synchronized (this) {
+            notify();
         }
-        try 
-        {
-            Thread.sleep(0,200); 
-        } 
-        catch(InterruptedException e) {}
-        
-        screenEvent = false; 
+        try {
+            Thread.sleep(0, 200);
+        } catch (InterruptedException e) {
+        }
+
+        screenEvent = false;
     }
-    
-    public void setScreenEvent(boolean hasEvent)
-    {
+
+    public void setScreenEvent(boolean hasEvent) {
         this.screenEvent = hasEvent;
     }
 }

--- a/src/JSqueak/Starter.java
+++ b/src/JSqueak/Starter.java
@@ -29,54 +29,50 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-public class Starter 
-{
+public class Starter {
     /**
      * The file name of the mini image.
      */
     private static final String MINI_IMAGE = "mini.image.gz";
-    
+
     /**
      * Locate a startable image as a resource.
      */
-    private static SqueakImage locateStartableImage() throws IOException 
-    {
+    private static SqueakImage locateStartableImage() throws IOException {
         //File saved= new File( pathname );
         //if (saved.exists()) return new SqueakImage(saved);
         // and only if no image name was given
-        URL imageUrl = Starter.class.getResource( MINI_IMAGE );
-        if ( "file".equals( imageUrl.getProtocol() ) )
-            return new SqueakImage( new File( imageUrl.getPath() ) );
-            
-        InputStream ims = Starter.class.getResourceAsStream( MINI_IMAGE );
-        if ( ims != null )
+        URL imageUrl = Starter.class.getResource(MINI_IMAGE);
+        if ("file".equals(imageUrl.getProtocol()))
+            return new SqueakImage(new File(imageUrl.getPath()));
+
+        InputStream ims = Starter.class.getResourceAsStream(MINI_IMAGE);
+        if (ims != null)
             return new SqueakImage(ims);
-        
-        throw new FileNotFoundException( "Cannot locate resource " + MINI_IMAGE );
+
+        throw new FileNotFoundException("Cannot locate resource " + MINI_IMAGE);
     }
 
     /**
      * Locate a startable image at a specified path.
      */
-    private static SqueakImage locateSavedImage( String pathname ) throws IOException 
-    {
-        File saved = new File( pathname );
-        if ( saved.exists() )
-            return new SqueakImage( saved );
-        
-        throw new FileNotFoundException( "Cannot locate image " + pathname );
+    private static SqueakImage locateSavedImage(String pathname) throws IOException {
+        File saved = new File(pathname);
+        if (saved.exists())
+            return new SqueakImage(saved);
+
+        throw new FileNotFoundException("Cannot locate image " + pathname);
     }
-    
+
     /**
      * @param args first arg may specify image file name
      */
-    public static void main(String[] args) throws IOException, NullPointerException, java.lang.ArrayIndexOutOfBoundsException 
-    {
+    public static void main(String[] args) throws IOException, NullPointerException, java.lang.ArrayIndexOutOfBoundsException {
         SqueakVM.initSmallIntegerCache();
-        SqueakImage img = args.length > 0 ? locateSavedImage( args[1] )
-                                          : locateStartableImage();
-        SqueakVM vm= new SqueakVM(img);
-        vm.run(); 
+        SqueakImage img = args.length > 0 ? locateSavedImage(args[1])
+                : locateStartableImage();
+        SqueakVM vm = new SqueakVM(img);
+        vm.run();
     }
 
     //Simulation sim= new Simulation(vm);

--- a/src/JSqueak/input/InputNotifyThread.java
+++ b/src/JSqueak/input/InputNotifyThread.java
@@ -5,7 +5,6 @@ import JSqueak.SqueakVM;
 /**
  * InputNotifyThread will notify VM input events
  * at a fixed-frequency
- *
  */
 public class InputNotifyThread extends Thread {
 

--- a/src/JSqueak/input/KeyboardQueue.java
+++ b/src/JSqueak/input/KeyboardQueue.java
@@ -9,10 +9,9 @@ import JSqueak.SqueakVM;
 
 /**
  * I'm JSqueak's keyboard driver.  I convert Java KeyEvents into Squeak
- * key and modifier key press events. 
+ * key and modifier key press events.
  */
-public class KeyboardQueue implements KeyListener
-{
+public class KeyboardQueue implements KeyListener {
     /**
      * The size of the character queue.
      */
@@ -21,143 +20,132 @@ public class KeyboardQueue implements KeyListener
     /**
      * See instance methods of InputSensor.
      */
-    private static final int 
-        SHIFT_KEY              =  8,
-        CONTROL_KEY            = 16,
-        COMMAND_KEY            = 64;
-    
+    private static final int
+            SHIFT_KEY = 8,
+            CONTROL_KEY = 16,
+            COMMAND_KEY = 64;
+
     /**
      * See ParagraphEditor class>>initializeCmdKeyShortcuts.
      */
-    private static final char 
-        CURSOR_HOME            =  1, 
-        CURSOR_END             =  4, 
-        CR_WITH_IDENT          = 13,
-        SELECT_CURRENT_TYPE_IN = 27, // TODO: Interesting, find out what it does
-        CURSOR_LEFT            = 28,
-        CURSOR_RIGHT           = 29,
-        CURSOR_UP              = 30,
-        CURSOR_DOWN            = 31;
+    private static final char
+            CURSOR_HOME = 1,
+            CURSOR_END = 4,
+            CR_WITH_IDENT = 13,
+            SELECT_CURRENT_TYPE_IN = 27, // TODO: Interesting, find out what it does
+            CURSOR_LEFT = 28,
+            CURSOR_RIGHT = 29,
+            CURSOR_UP = 30,
+            CURSOR_DOWN = 31;
 
     /**
      * Squeak keys that do not map to Java key events. Order *MUST* match that of JAVA_KEYS.
      */
     private static final char[] SQUEAK_KEYS =
-    {
-        CURSOR_HOME,
-        CURSOR_END,
-        CR_WITH_IDENT,
-        CURSOR_LEFT,
-        CURSOR_RIGHT,
-        CURSOR_UP,
-        CURSOR_DOWN,
-        SELECT_CURRENT_TYPE_IN,
-    };
+            {
+                    CURSOR_HOME,
+                    CURSOR_END,
+                    CR_WITH_IDENT,
+                    CURSOR_LEFT,
+                    CURSOR_RIGHT,
+                    CURSOR_UP,
+                    CURSOR_DOWN,
+                    SELECT_CURRENT_TYPE_IN,
+            };
 
     /**
      * Counterpart of squeak keys.  Order *MUST* match that of SQUEAK_KEYS.
      */
     private static final int[] JAVA_KEYS =
-    { 
-        KeyEvent.VK_HOME,
-        KeyEvent.VK_END,
-        KeyEvent.VK_ENTER,
-        KeyEvent.VK_LEFT,
-        KeyEvent.VK_RIGHT,
-        KeyEvent.VK_UP,
-        KeyEvent.VK_DOWN,
-        KeyEvent.VK_BACK_QUOTE,
-    };
-    
+            {
+                    KeyEvent.VK_HOME,
+                    KeyEvent.VK_END,
+                    KeyEvent.VK_ENTER,
+                    KeyEvent.VK_LEFT,
+                    KeyEvent.VK_RIGHT,
+                    KeyEvent.VK_UP,
+                    KeyEvent.VK_DOWN,
+                    KeyEvent.VK_BACK_QUOTE,
+            };
+
     private final SqueakVM fSqueakVM;
-    
+
     private final List fCharQueue = new ArrayList();
-    
+
     private int fModifierKeys = 0;
-    
-    public KeyboardQueue( SqueakVM squeakVM )
-    {
+
+    public KeyboardQueue(SqueakVM squeakVM) {
         fSqueakVM = squeakVM;
     }
-    
+
     // -- JSqueak interface
-    
-    public int peek() 
-    {
-        return fCharQueue.isEmpty() ? 0 : keycode( (Character) fCharQueue.get( 0 ) ); 
-    }
-    
-    public int next() 
-    {
-        return keycode( (Character) fCharQueue.remove( 0 ) ); 
+
+    public int peek() {
+        return fCharQueue.isEmpty() ? 0 : keycode((Character) fCharQueue.get(0));
     }
 
-    public int modifierKeys() 
-    {
+    public int next() {
+        return keycode((Character) fCharQueue.remove(0));
+    }
+
+    public int modifierKeys() {
         return fModifierKeys;
     }
-    
+
     // -- KeyListener methods
-    
-    public void keyPressed( KeyEvent event ) 
-    {
-        fModifierKeys = mapModifierKey( event );
-        char keyChar = mapSpecialKey( event );
-        if ( keyChar != KeyEvent.CHAR_UNDEFINED )
-            addToQueue( keyChar );
+
+    public void keyPressed(KeyEvent event) {
+        fModifierKeys = mapModifierKey(event);
+        char keyChar = mapSpecialKey(event);
+        if (keyChar != KeyEvent.CHAR_UNDEFINED)
+            addToQueue(keyChar);
     }
-    
-    public void keyReleased( KeyEvent event ) 
-    {
-        fModifierKeys = mapModifierKey( event );
+
+    public void keyReleased(KeyEvent event) {
+        fModifierKeys = mapModifierKey(event);
     }
-    
-    public  void keyTyped( KeyEvent event )
-    {
+
+    public void keyTyped(KeyEvent event) {
         // Ignore the return key, mapSpecialKey() took care of it
-        if ( event.getKeyChar() == '\n' )
+        if (event.getKeyChar() == '\n')
             return;
-        
-        addToQueue( event.getKeyChar() );
+
+        addToQueue(event.getKeyChar());
     }
 
     // -- Private methods
-    
-    private void addToQueue( char keyChar )
-    {
-        if ( fCharQueue.size() < TYPEAHEAD_LIMIT )
-            fCharQueue.add( new Character( keyChar ) );
+
+    private void addToQueue(char keyChar) {
+        if (fCharQueue.size() < TYPEAHEAD_LIMIT)
+            fCharQueue.add(new Character(keyChar));
     }
-    
-    private static int mapModifierKey( KeyEvent event ) 
-    {
+
+    private static int mapModifierKey(KeyEvent event) {
         int modifiers = 0;
-        if ( event.isShiftDown() )
+        if (event.isShiftDown())
             modifiers |= SHIFT_KEY;
-        if ( event.isControlDown() )
+        if (event.isControlDown())
             modifiers |= CONTROL_KEY;
-        if ( event.isAltDown() || event.isMetaDown() )
+        if (event.isAltDown() || event.isMetaDown())
             modifiers |= COMMAND_KEY;
-        
+
         return modifiers;
     }
-    
-    private static char mapSpecialKey( KeyEvent evt ) 
-    {
+
+    private static char mapSpecialKey(KeyEvent evt) {
         int specialKeyIndex = 0;
-        while ( specialKeyIndex < JAVA_KEYS.length && JAVA_KEYS[ specialKeyIndex ] != evt.getKeyCode() ) 
+        while (specialKeyIndex < JAVA_KEYS.length && JAVA_KEYS[specialKeyIndex] != evt.getKeyCode())
             specialKeyIndex++;
-        if ( specialKeyIndex < JAVA_KEYS.length )
-            return SQUEAK_KEYS[ specialKeyIndex ];
-        
-        if ( evt.isAltDown() )
-            return Character.toLowerCase( (char) evt.getKeyCode() );
-        
+        if (specialKeyIndex < JAVA_KEYS.length)
+            return SQUEAK_KEYS[specialKeyIndex];
+
+        if (evt.isAltDown())
+            return Character.toLowerCase((char) evt.getKeyCode());
+
         return KeyEvent.CHAR_UNDEFINED;
     }
 
-    private static int keycode( Character c ) 
-    {
-        return c.charValue() & 255; 
+    private static int keycode(Character c) {
+        return c.charValue() & 255;
     }
 }

--- a/src/JSqueak/input/MouseStatus.java
+++ b/src/JSqueak/input/MouseStatus.java
@@ -6,58 +6,53 @@ import javax.swing.event.MouseInputAdapter;
 
 import JSqueak.SqueakVM;
 
-public class MouseStatus extends MouseInputAdapter 
-{
+public class MouseStatus extends MouseInputAdapter {
     private final SqueakVM fSqueakVM;
-    
+
     public int fX, fY;
     public int fButtons;
-    
+
     private final static int RED = 4;
     private final static int YELLOW = 2;
     private final static int BLUE = 1;
-    
-    public MouseStatus( SqueakVM squeakVM )
-    {
+
+    public MouseStatus(SqueakVM squeakVM) {
         fSqueakVM = squeakVM;
     }
-    
-    private int mapButton(MouseEvent evt) 
-    {
-        switch (evt.getButton()) 
-        {
+
+    private int mapButton(MouseEvent evt) {
+        switch (evt.getButton()) {
             case MouseEvent.BUTTON1:
-                if (evt.isControlDown()) 
+                if (evt.isControlDown())
                     return YELLOW;
-                if (evt.isAltDown()) 
+                if (evt.isAltDown())
                     return BLUE;
                 return RED;
-            case MouseEvent.BUTTON2:    return BLUE;        // middle (frame menu)
-            case MouseEvent.BUTTON3:    return YELLOW;  // right (pane menu)
-            case MouseEvent.NOBUTTON:   return 0;
+            case MouseEvent.BUTTON2:
+                return BLUE;        // middle (frame menu)
+            case MouseEvent.BUTTON3:
+                return YELLOW;  // right (pane menu)
+            case MouseEvent.NOBUTTON:
+                return 0;
         }
-        throw new RuntimeException("unknown mouse button in event"); 
+        throw new RuntimeException("unknown mouse button in event");
     }
-    
-    public void mouseMoved(MouseEvent evt) 
-    {
+
+    public void mouseMoved(MouseEvent evt) {
         fX = evt.getX();
         fY = evt.getY();
     }
-    
-    public void mouseDragged(MouseEvent evt) 
-    {
-        fX= evt.getX();
-        fY= evt.getY();
+
+    public void mouseDragged(MouseEvent evt) {
+        fX = evt.getX();
+        fY = evt.getY();
     }
-    
-    public void mousePressed(MouseEvent evt) 
-    {
-        fButtons |= mapButton(evt); 
+
+    public void mousePressed(MouseEvent evt) {
+        fButtons |= mapButton(evt);
     }
-    
-    public void mouseReleased(MouseEvent evt) 
-    {
+
+    public void mouseReleased(MouseEvent evt) {
         fButtons &= ~mapButton(evt);
     }
 }

--- a/src/JSqueak/utils/ScreenUtils.java
+++ b/src/JSqueak/utils/ScreenUtils.java
@@ -1,0 +1,84 @@
+package JSqueak.utils;
+
+import java.awt.*;
+import java.awt.image.ColorModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.IndexColorModel;
+
+public class ScreenUtils {
+
+    // cf. http://doc.novsu.ac.ru/oreilly/java/awt/ch12_02.htm
+    private final static byte[] kComponents =
+            new byte[]{(byte) 255, 0, (byte) 240, (byte) 230,
+                    (byte) 220, (byte) 210, (byte) 200, (byte) 190, (byte) 180, (byte) 170,
+                    (byte) 160, (byte) 150, 110, 70, 30, 10};
+
+    private final static byte[] fComponents =
+            new byte[]{(byte) 255, (byte) 240, (byte) 230,
+                    (byte) 220, (byte) 210, (byte) 200, (byte) 190, (byte) 180, (byte) 170,
+                    (byte) 160, (byte) 150, 110, 70, 30, 10};
+
+    private final static byte[] sComponentsR = new byte[256];
+    private final static byte[] sComponentsG = new byte[256];
+    private final static byte[] sComponentsB = new byte[256];
+    private final static byte[] sComponentsA = new byte[256];
+
+    private final static int[] palette = {
+            0x00ff0000,       // Red
+            0x0000ff00,       // Green
+            0x000000ff,       // Blue
+            0xff000000,        // Alpha
+    };
+
+    static {
+        for (int i = 0; i < 256; i++) {
+            sComponentsR[i] = (byte) (i);
+            sComponentsG[i] = (byte) (i);
+            sComponentsB[i] = (byte) (i);
+            sComponentsA[i] = (byte) (Transparency.TRANSLUCENT);
+        }
+    }
+
+    public static ColorModel getBlackWhiteModel() {
+        return new IndexColorModel(1, 2, kComponents, kComponents, kComponents);
+    }
+
+    public static ColorModel get256ColorModel() {
+        // indexedColors array copy from SqueakJS
+        int[] indexedColors = new int[]{
+                0xFFFFFFFF, 0xFF000001, 0xFFFFFFFF, 0xFF808080, 0xFFFF0000, 0xFF00FF00, 0xFF0000FF, 0xFF00FFFF,
+                0xFFFFFF00, 0xFFFF00FF, 0xFF202020, 0xFF404040, 0xFF606060, 0xFF9F9F9F, 0xFFBFBFBF, 0xFFDFDFDF,
+                0xFF080808, 0xFF101010, 0xFF181818, 0xFF282828, 0xFF303030, 0xFF383838, 0xFF484848, 0xFF505050,
+                0xFF585858, 0xFF686868, 0xFF707070, 0xFF787878, 0xFF878787, 0xFF8F8F8F, 0xFF979797, 0xFFA7A7A7,
+                0xFFAFAFAF, 0xFFB7B7B7, 0xFFC7C7C7, 0xFFCFCFCF, 0xFFD7D7D7, 0xFFE7E7E7, 0xFFEFEFEF, 0xFFF7F7F7,
+                0xFF000001, 0xFF003300, 0xFF006600, 0xFF009900, 0xFF00CC00, 0xFF00FF00, 0xFF000033, 0xFF003333,
+                0xFF006633, 0xFF009933, 0xFF00CC33, 0xFF00FF33, 0xFF000066, 0xFF003366, 0xFF006666, 0xFF009966,
+                0xFF00CC66, 0xFF00FF66, 0xFF000099, 0xFF003399, 0xFF006699, 0xFF009999, 0xFF00CC99, 0xFF00FF99,
+                0xFF0000CC, 0xFF0033CC, 0xFF0066CC, 0xFF0099CC, 0xFF00CCCC, 0xFF00FFCC, 0xFF0000FF, 0xFF0033FF,
+                0xFF0066FF, 0xFF0099FF, 0xFF00CCFF, 0xFF00FFFF, 0xFF330000, 0xFF333300, 0xFF336600, 0xFF339900,
+                0xFF33CC00, 0xFF33FF00, 0xFF330033, 0xFF333333, 0xFF336633, 0xFF339933, 0xFF33CC33, 0xFF33FF33,
+                0xFF330066, 0xFF333366, 0xFF336666, 0xFF339966, 0xFF33CC66, 0xFF33FF66, 0xFF330099, 0xFF333399,
+                0xFF336699, 0xFF339999, 0xFF33CC99, 0xFF33FF99, 0xFF3300CC, 0xFF3333CC, 0xFF3366CC, 0xFF3399CC,
+                0xFF33CCCC, 0xFF33FFCC, 0xFF3300FF, 0xFF3333FF, 0xFF3366FF, 0xFF3399FF, 0xFF33CCFF, 0xFF33FFFF,
+                0xFF660000, 0xFF663300, 0xFF666600, 0xFF669900, 0xFF66CC00, 0xFF66FF00, 0xFF660033, 0xFF663333,
+                0xFF666633, 0xFF669933, 0xFF66CC33, 0xFF66FF33, 0xFF660066, 0xFF663366, 0xFF666666, 0xFF669966,
+                0xFF66CC66, 0xFF66FF66, 0xFF660099, 0xFF663399, 0xFF666699, 0xFF669999, 0xFF66CC99, 0xFF66FF99,
+                0xFF6600CC, 0xFF6633CC, 0xFF6666CC, 0xFF6699CC, 0xFF66CCCC, 0xFF66FFCC, 0xFF6600FF, 0xFF6633FF,
+                0xFF6666FF, 0xFF6699FF, 0xFF66CCFF, 0xFF66FFFF, 0xFF990000, 0xFF993300, 0xFF996600, 0xFF999900,
+                0xFF99CC00, 0xFF99FF00, 0xFF990033, 0xFF993333, 0xFF996633, 0xFF999933, 0xFF99CC33, 0xFF99FF33,
+                0xFF990066, 0xFF993366, 0xFF996666, 0xFF999966, 0xFF99CC66, 0xFF99FF66, 0xFF990099, 0xFF993399,
+                0xFF996699, 0xFF999999, 0xFF99CC99, 0xFF99FF99, 0xFF9900CC, 0xFF9933CC, 0xFF9966CC, 0xFF9999CC,
+                0xFF99CCCC, 0xFF99FFCC, 0xFF9900FF, 0xFF9933FF, 0xFF9966FF, 0xFF9999FF, 0xFF99CCFF, 0xFF99FFFF,
+                0xFFCC0000, 0xFFCC3300, 0xFFCC6600, 0xFFCC9900, 0xFFCCCC00, 0xFFCCFF00, 0xFFCC0033, 0xFFCC3333,
+                0xFFCC6633, 0xFFCC9933, 0xFFCCCC33, 0xFFCCFF33, 0xFFCC0066, 0xFFCC3366, 0xFFCC6666, 0xFFCC9966,
+                0xFFCCCC66, 0xFFCCFF66, 0xFFCC0099, 0xFFCC3399, 0xFFCC6699, 0xFFCC9999, 0xFFCCCC99, 0xFFCCFF99,
+                0xFFCC00CC, 0xFFCC33CC, 0xFFCC66CC, 0xFFCC99CC, 0xFFCCCCCC, 0xFFCCFFCC, 0xFFCC00FF, 0xFFCC33FF,
+                0xFFCC66FF, 0xFFCC99FF, 0xFFCCCCFF, 0xFFCCFFFF, 0xFFFF0000, 0xFFFF3300, 0xFFFF6600, 0xFFFF9900,
+                0xFFFFCC00, 0xFFFFFF00, 0xFFFF0033, 0xFFFF3333, 0xFFFF6633, 0xFFFF9933, 0xFFFFCC33, 0xFFFFFF33,
+                0xFFFF0066, 0xFFFF3366, 0xFFFF6666, 0xFFFF9966, 0xFFFFCC66, 0xFFFFFF66, 0xFFFF0099, 0xFFFF3399,
+                0xFFFF6699, 0xFFFF9999, 0xFFFFCC99, 0xFFFFFF99, 0xFFFF00CC, 0xFFFF33CC, 0xFFFF66CC, 0xFFFF99CC,
+                0xFFFFCCCC, 0xFFFFFFCC, 0xFFFF00FF, 0xFFFF33FF, 0xFFFF66FF, 0xFFFF99FF, 0xFFFFCCFF, 0xFFFFFFFF};
+
+        return new IndexColorModel(8, 256, indexedColors, 0, false, 256, DataBuffer.TYPE_BYTE);
+    }
+}

--- a/src/JSqueak/utils/SqueakLogger.java
+++ b/src/JSqueak/utils/SqueakLogger.java
@@ -1,0 +1,19 @@
+package JSqueak.utils;
+
+
+import JSqueak.SqueakConfig;
+
+public class SqueakLogger {
+
+    public static void log_D(String msg) {
+        if (SqueakConfig.DEBUG_LOGGING) {
+            System.out.println(msg);
+        }
+    }
+
+    public static void log_E(String msg) {
+        if (SqueakConfig.DEBUG_LOGGING) {
+            System.err.println(msg);
+        }
+    }
+}


### PR DESCRIPTION
Hi Victor

I have reformated code with Intellij IDEA, which is more popular than Eclipse nowadays.

The major improvement is the support for window resizing, by adding a ComponentListener to JFrame and reimplementing primitiveScreenSize, now JSqueak can respond to window size changes , after applying "restore display" x2 manually, JSqueak will recreate displayAdapter and display correctly.

I also add 8-bit color mode for displayAdapter, but characters are not displayed correctly, since loadColorMap() and many BitBlt operation are not yet implemented.
So I will open another PR for the 8-bit color display, this work has been completed on another separate branch, it will take some time to back port those changes, and if it is possible, I will also merge the 32-bit color support from Potato (the implementations are almost the same).